### PR TITLE
chore(deps): pnpm.overrides 보안 핀 15개 제거

### DIFF
--- a/.claude/docs/build-pipeline-gotchas.md
+++ b/.claude/docs/build-pipeline-gotchas.md
@@ -31,10 +31,10 @@ Read this when: modifying `next.config.js`, `package.json` scripts, `eslint.conf
 - `prepare` script MUST be `husky` (not `husky install`, which is deprecated in v9).
 - The `.husky/_/` directory is generated locally by the `prepare` script; it MUST NOT be committed.
 
-### `pnpm.overrides` are security pins
-- Many entries in `package.json` `pnpm.overrides` exist purely to satisfy Dependabot alerts on transitive deps (lodash, flatted, immutable, etc.).
-- NEVER trim them without confirming via `pnpm why <pkg>` that the parent dependency tree no longer requires the vulnerable range.
-- See issue #87 for the planned cleanup pass.
+### `pnpm.overrides`: when to add a pin
+- `package.json` currently has no `pnpm.overrides` block. Issue #87 audited the 15 security pins inherited from issue #85 and confirmed all were redundant after the Next 15 + React 19 upgrade — every transitive dependency naturally resolves to a version at or above the GHSA-safe floor.
+- If a future Dependabot alert demands a pin, ADD a fresh `pnpm.overrides` entry only after confirming via `pnpm why <pkg>` that the parent dependency tree still pulls a vulnerable range. Verify the floor exists as a published version (a previous pin like `lodash: ">=4.18.0"` was unsatisfiable because lodash 4.x maxes at 4.17.21).
+- When a transitive has multiple major versions live in the tree, pin per affected major. Example from the #87 audit: `semver` runs at both 6.x and 7.x; a single `>=7.5.2` silently fails to apply to a `^6` parent. The audit found 6.3.1 already meets the GHSA-c2qf-rxjj-qqgw safe threshold for the 6.x line, so the pin was unnecessary — but if a future GHSA forces a 6.x bump, write the override as a range that covers each major separately.
 
 ### ESLint CLI: `eslint .` scans everything — explicit ignores required
 

--- a/package.json
+++ b/package.json
@@ -42,24 +42,5 @@
     "tailwindcss": "^4.3.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.2"
-  },
-  "pnpm": {
-    "overrides": {
-      "lodash": ">=4.18.0",
-      "flatted": ">=3.4.2",
-      "immutable": ">=4.3.8",
-      "yaml": ">=1.10.3",
-      "js-yaml": ">=4.1.1",
-      "minimatch": ">=3.1.3",
-      "json5": ">=1.0.2",
-      "word-wrap": ">=1.2.4",
-      "braces": ">=3.0.3",
-      "micromatch": ">=4.0.8",
-      "cross-spawn": ">=7.0.5",
-      "nanoid": ">=3.3.8",
-      "postcss": ">=8.4.31",
-      "semver": ">=7.5.2",
-      "picomatch": ">=2.3.2"
-    }
   }
 }


### PR DESCRIPTION
## 요약
이슈 #85에서 Dependabot 알림 대응으로 추가했던 `package.json`의 `pnpm.overrides` 15개 핀이 Next 15 + React 19 메이저 업그레이드 이후 모두 redundant임을 감사로 확인하고 일괄 제거. `pnpm install` 후 lockfile 변경이 없어 redundancy를 입증했고, 관련 가이드는 `build-pipeline-gotchas.md`에 갱신했습니다.

## 변경 사항
- `package.json`: `pnpm.overrides` 블록과 `pnpm` 키 전체 제거(-19라인)
- `.claude/docs/build-pipeline-gotchas.md`: "security pins" 섹션을 "when to add a pin"으로 재작성하고 향후 핀 추가 가이드(미존재 floor 함정·다중 메이저 분리 핀) 반영
- `pnpm-lock.yaml`: **변경 없음** — 자연 해결 버전과 override 적용 버전이 완전히 동일

## 감사 결정표

| 패키지 | 자연 해결 | floor | 판정 | 사유 |
|---|---|---|---|---|
| lodash | 미설치 | >=4.18.0 | drop | 트리에 없음 + floor 미존재 버전(4.x 최대 4.17.21) |
| flatted | 3.4.2 | >=3.4.2 | drop | 자연 해결 = floor |
| immutable | 미설치 | >=4.3.8 | drop | 트리에 없음 |
| yaml | 미설치 | >=1.10.3 | drop | 트리에 없음 |
| js-yaml | 4.1.1 | >=4.1.1 | drop | 자연 해결 = floor |
| minimatch | 3.1.5 / 9.0.9 / 10.2.5 | >=3.1.3 | drop | 최저 ≥ floor |
| json5 | 1.0.2 | >=1.0.2 | drop | 자연 해결 = floor |
| word-wrap | 1.2.5 | >=1.2.4 | drop | 자연 해결 > floor |
| braces | 3.0.3 | >=3.0.3 | drop | 자연 해결 = floor |
| micromatch | 4.0.8 | >=4.0.8 | drop | 자연 해결 = floor |
| cross-spawn | 7.0.6 | >=7.0.5 | drop | 자연 해결 > floor |
| nanoid | 3.3.12 | >=3.3.8 | drop | 자연 해결 > floor |
| postcss | 8.4.31 / 8.5.14 | >=8.4.31 | drop | 최저 = floor |
| semver | 6.3.1 / 7.8.0 | >=7.5.2 | drop | 6.x 부모(^6)에 비강제 — 6.3.1·7.8.0 모두 GHSA-c2qf-rxjj-qqgw 안전선 충족 |
| picomatch | 2.3.2 / 4.0.4 | >=2.3.2 | drop | 최저 = floor |

## 설계 결정
- `pnpm.overrides`를 빈 객체로 두기보다 `pnpm` 키 자체를 제거 — 빈 블록을 남기면 향후 "왜 비어있나" 컨텍스트 비용이 발생.
- semver 6.3.1은 이미 GHSA-c2qf-rxjj-qqgw 안전 임계점(6.3.1+)이므로 6.x 라인 별도 핀 불필요.

## 관련 이슈
Closes #87

## 테스트 체크리스트
- [x] `pnpm install --frozen-lockfile` — lockfile delta 0
- [x] `pnpm run lint` — exit 0
- [x] `pnpm run build` — 정적 export 성공
- [ ] **머지 후**: GitHub Dependabot 재스캔에서 Critical/High 알림 신규 발생 없는지 확인(out-of-scope: 신규 알림이 뜨면 별도 이슈로 처리)