### PR TITLE
ci: Slack 알림을 공식 액션으로 교체

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,8 +36,10 @@ jobs:
           add: -f ./docs
 
       - name: Notify via Slack
-        uses: joshmgross/send-slack-message@v1.0.1
+        uses: slackapi/slack-github-action@v2.1.1
         with:
-          message: "\n<!here> Code Logs built successfully. :+1:\n\n <http://code-logs.github.io|바로가기 :black_cat:>"
-          slack-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          channel: ${{ secrets.SLACK_CHANNEL }}
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "${{ secrets.SLACK_CHANNEL }}"
+            text: "\n<!here> Code Logs built successfully. :+1:\n\n <http://code-logs.github.io|바로가기 :black_cat:>"


### PR DESCRIPTION
## 요약
`.github/workflows/docs.yml`에서 사용 중이던 거의 유지보수가 중단된 `joshmgross/send-slack-message@v1.0.1`을 Slack 공식 액션 `slackapi/slack-github-action@v2.1.1`로 교체. 공급망 리스크 완화 + 향후 Slack API 변경 대응이 목적.

## 변경 사항
- `Notify via Slack` step의 `uses`를 `slackapi/slack-github-action@v2.1.1`로 교체 (정확한 패치 태그로 핀)
- 호출 형식을 `chat.postMessage` 메서드 기반으로 재작성: `slack-token` → `token`, `channel`/`message` → `payload` 내부로 이동
- 메시지 본문(`<!here>` mention, `<url|label>` 링크, 이모지)은 Slack mrkdwn에서 그대로 지원되므로 텍스트 동일하게 보존
- Secret 이름(`SLACK_BOT_TOKEN`, `SLACK_CHANNEL`) 변경 없음

## 관련 이슈
Closes #86

## 운영 노트
- `SLACK_CHANNEL` secret이 채널명(`#name`)으로 설정돼 있다면 봇이 해당 채널에 초대되어 있어야 정상 동작. 채널 ID로 설정돼 있다면 추가 작업 불필요. (기존 액션도 동일 제약)

## 테스트 체크리스트
- [ ] `main` push 후 `Docs` 워크플로우가 성공적으로 완료되는지 확인
- [ ] Slack 채널에 메시지가 도착하고 `<!here>` mention이 활성화되는지 확인
- [ ] `바로가기` 링크가 클릭 가능하고 `code-logs.github.io`로 이동하는지 확인
- [ ] 이모지(`:+1:`, `:black_cat:`)가 정상 렌더링되는지 확인
- [ ] 필요시 `workflow_dispatch`로 prod 머지 전 사전 실행