### PR TITLE
docs(readme): setup·개발 가이드 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,58 @@
 
 [![Docs](https://github.com/code-logs/code-logs.github.io/actions/workflows/docs.yml/badge.svg)](https://github.com/code-logs/code-logs.github.io/actions/workflows/docs.yml)
 
+개인 기술 블로그. GitHub Pages 정적 export로 운영됩니다.
+
+## Stack
+
+- Next.js 15 (Pages Router) + React 19 + TypeScript
+- Tailwind CSS v4 (CSS-first config)
+- GitHub Pages 정적 export (`output: 'export'`)
+
+## Prerequisites
+
+- **Node 22** — `.nvmrc`에 핀 되어 있음
+- **Corepack** — `package.json`의 `packageManager` 필드 기반으로 pnpm 버전을 자동 부트스트랩
+
+## Getting started
+
+```bash
+nvm use            # .nvmrc 기반 Node 22
+corepack enable    # packageManager 필드 기반 pnpm 자동 활성화 (머신당 1회)
+pnpm install
+pnpm run dev       # http://localhost:3000
+```
+
+## Available scripts
+
+모든 스크립트는 `pnpm run <script>` 형태로 실행합니다. bare `pnpm <script>`는 pnpm 내장 서브커맨드(`docs`, `licenses` 등)와 충돌하므로 피합니다.
+
+| Script | 설명 |
+|--------|------|
+| `pnpm run dev` | Next.js dev 서버 |
+| `pnpm run build` | 프로덕션 빌드 (정적 export, `./out`) |
+| `pnpm run docs` | 전체 export 파이프라인 — clean → build → `./out` → `./docs` 이동 → `.nojekyll` → sitemap |
+| `pnpm run sitemap` | 빌드된 `./docs`를 대상으로 sitemap 생성 |
+| `pnpm run lint` | ESLint (flat config) |
+| `pnpm run licenses` | `public/licenses.json` 재생성 |
+
+## Adding a post
+
+포스트는 두 곳에 동시 등록되어야 노출됩니다.
+
+1. 본문: `posts/<category>/<file>.md`
+2. 메타: `config/posts.config.ts`의 `posts` 배열에 `Post` 엔트리 추가 — `title`, `description`, `category`(`CATEGORIES` 키), `published`, `publishedAt`, `thumbnailName`, `tags` 등
+
+`config/posts.config.ts`에 항목이 없거나 `published: false`이면 빌드 결과에서 제외됩니다. 카테고리 키는 `posts/` 하위 디렉터리명과 일치해야 합니다. 상세 동작(빌드 시 routing, sitemap 흐름 등)은 [CLAUDE.md](./CLAUDE.md)의 "Post pipeline" 섹션을 참고하세요.
+
+## Deployment
+
+`main` 브랜치에 push되면 [`.github/workflows/docs.yml`](.github/workflows/docs.yml)이 자동으로 `pnpm run docs`를 실행하고, 생성된 `./docs` 디렉터리를 `main`에 force-commit합니다. GitHub Pages는 이 `./docs` 디렉터리를 서빙합니다.
+
+> **`./docs` 디렉터리는 빌드 산출물입니다. 수동으로 편집하지 마세요** — 다음 `main` push 때 CI가 덮어씁니다. 소스만 수정하고 CI가 재생성하도록 둡니다.
+
+## Project docs
+
+- [CLAUDE.md](./CLAUDE.md) — 아키텍처, post 파이프라인, 라우팅 컨벤션, 환경 변수 등
+- [.claude/docs/index.md](./.claude/docs/index.md) — 빌드 파이프라인 / 스타일링 / 아이콘 라이브러리 등 누적된 작업 노트
+- [.claude/docs/build-pipeline-gotchas.md](./.claude/docs/build-pipeline-gotchas.md) — 빌드/배포 설정 변경 전 반드시 확인할 함정 모음


### PR DESCRIPTION
## 요약
README가 빌드 배지 한 줄뿐이어서 셋업·배포 흐름을 빠르게 잡기 어려웠던 점을 해결.
Node 22 + Corepack + pnpm 기반 toolchain(#85에서 도입)과 정적 export 배포 흐름을 정리.

## 변경 사항
- Stack / Prerequisites / Getting started / Available scripts 섹션 추가
- 모든 스크립트 명령을 `pnpm run <script>` 형태로 통일 (bare 형 충돌 회피)
- Adding a post: `posts/<category>/<file>.md` + `config/posts.config.ts` 2단계 등록 명시
- Deployment: `main` push → CI가 `./docs` 자동 생성/커밋, 수동 편집 금지 경고
- Project docs: `CLAUDE.md`, `.claude/docs/index.md`, `build-pipeline-gotchas.md` 링크
- 개인 프로젝트이므로 외부 기여자 대상 Contributing 섹션은 의도적으로 제외

## 관련 이슈
Closes #89

## 테스트 체크리스트
- [ ] GitHub UI에서 README 렌더링 확인 (상대 링크 \`./CLAUDE.md\`, \`./.claude/docs/index.md\`, \`./.claude/docs/build-pipeline-gotchas.md\` 동작)
- [ ] 명시한 셋업 시퀀스(\`nvm use\` → \`corepack enable\` → \`pnpm install\` → \`pnpm run dev\`)로 dev 서버 기동
- [ ] Available scripts 표의 모든 명령이 \`pnpm run <script>\` 형태인지 확인