### PR TITLE
feat(about): 운영자 소개·블로그 정체성 섹션 추가

### DIFF
--- a/.claude/docs/build-pipeline-gotchas.md
+++ b/.claude/docs/build-pipeline-gotchas.md
@@ -12,6 +12,7 @@ Read this when: modifying `next.config.js`, `package.json` scripts, `eslint.conf
 - With `output: 'export'`, Next writes the static export to `out/` regardless of `distDir`. `distDir` only relocates the `.next/` build cache.
 - NEVER set `distDir: 'docs'`. We tried it once: `BUILD_ID` and other cache files leaked into `docs/`, and `docs:clean` then deleted them every build, forcing a full re-build.
 - The `docs` script moves `out/` to `docs/` after `next build` completes (`mv ./out ./docs`).
+- For the rendering-side implications of `output: 'export'` (hydration mismatch when a page depends on `new Date()` or other host-runtime values), see [static-export-rendering-gotchas.md](static-export-rendering-gotchas.md).
 
 ### pnpm 11 blocks build scripts and exotic git subdeps
 - pnpm 11 throws a hard error on first install for packages with native postinstall scripts (`sharp`, `@parcel/watcher`, `unrs-resolver`). Approve them in `pnpm-workspace.yaml` under `allowBuilds` (the legacy `package.json` `pnpm.onlyBuiltDependencies` is removed).

--- a/.claude/docs/index.md
+++ b/.claude/docs/index.md
@@ -8,4 +8,5 @@ Read this when: you need to find project knowledge documents written by AI agent
 |---|---|
 | Why the build pipeline is shaped the way it is, and what NOT to change | [build-pipeline-gotchas.md](build-pipeline-gotchas.md) |
 | Why a lucide icon won't size via `font-size`, or where a brand icon went | [icon-library-gotchas.md](icon-library-gotchas.md) |
+| How to safely depend on dates, randomness, or other host-runtime values inside a page under `output: 'export'` | [static-export-rendering-gotchas.md](static-export-rendering-gotchas.md) |
 | How Tailwind v4 is set up here, and what classes/tokens MUST NOT be changed | [styling-gotchas.md](styling-gotchas.md) |

--- a/.claude/docs/static-export-rendering-gotchas.md
+++ b/.claude/docs/static-export-rendering-gotchas.md
@@ -1,0 +1,60 @@
+# Static Export Rendering Gotchas
+
+Read this when: adding or editing any page under `pages/` that references a value derived from the host runtime — current date/time, random numbers, environment-specific state — or adding any computation at module scope or in the component body that could be evaluated at both build time and hydration time.
+
+## Overview
+
+The site builds with `output: 'export'` (Next.js 15 Pages Router) and is served as plain static HTML by GitHub Pages. Each page is pre-rendered to HTML once at build time, then the client hydrates that HTML with the same React tree. Anything that evaluates differently between the build-time render and the client hydration render becomes (1) a React hydration mismatch warning in dev, (2) a visible stale-vs-fresh discrepancy in production after the HTML ages, and (3) a permanently stale value to JS-less crawlers.
+
+## Pitfalls
+
+### `new Date()` / `Date.now()` at module scope or in the component body drifts between build and hydration
+
+- **Symptom:** A page shows a date-derived value (current year, "X년차", "N days ago"). The HTML served by GitHub Pages keeps showing the value baked at the last CI build; once the calendar advances past the next boundary (new year, day rollover), the client hydration re-evaluates `new Date()` to a fresh value and React logs a hydration mismatch in dev. JS-less crawlers see only the stale HTML value forever.
+- **Why:** Module-scope code and component-body code execute in two contexts under `output: 'export'`: the Node build process (its result is baked into the static HTML) and the client bundle at hydration. The two evaluations of `new Date()` / `Date.now()` see different clocks. Static export has no per-request server render to reconcile them.
+- **Rule:** Compute time-dependent values inside `getStaticProps` and pass them down as props. `getStaticProps` runs only at build time, is stripped from the client bundle, and feeds the same value into the HTML and the hydrated tree.
+
+## Conventions
+
+- ALWAYS source build-time-constant values (current year, computed offsets from a fixed start year, build timestamp) from `getStaticProps`, never from module scope or the component body.
+- NEVER call `new Date()` or `Date.now()` outside `getStaticProps` for values that must match the static HTML. The exception is values that are intentionally client-only (e.g., the visitor's local clock), which MUST be guarded behind `useEffect` with an initial empty/placeholder state so the first paint matches the HTML.
+- ALWAYS type the prop contract with `GetStaticProps<Props>` so the build-time-to-component handoff is checked.
+- The same rule applies to `Math.random()` and any other non-deterministic source: pin it in `getStaticProps` or push it strictly client-side behind `useEffect`.
+
+## Examples
+
+```tsx
+// ❌ Wrong — module-scope evaluation drifts between build HTML and hydration.
+const CAREER_START_YEAR = 2015
+const CAREER_YEARS = new Date().getFullYear() - CAREER_START_YEAR
+
+const About = () => <p>현재 {CAREER_YEARS}년차입니다.</p>
+export default About
+```
+
+```tsx
+// ✅ Right — pinned at build time, passed as a prop.
+import type { GetStaticProps } from 'next'
+
+const CAREER_START_YEAR = 2015
+
+interface AboutProps {
+  careerYears: number
+}
+
+const About = ({ careerYears }: AboutProps) => (
+  <p>현재 {careerYears}년차입니다.</p>
+)
+
+export const getStaticProps: GetStaticProps<AboutProps> = async () => ({
+  props: { careerYears: new Date().getFullYear() - CAREER_START_YEAR },
+})
+
+export default About
+```
+
+## Rationale
+
+The HTML emitted by `next build` under `output: 'export'` is the artifact GitHub Pages serves and the only thing a JS-less crawler ever sees. There is no SSR fallback to reconcile drift, so any value that is not pinned at build time becomes a divergence between the served HTML and the live React tree the moment the host clock advances past a boundary. `getStaticProps` is the only Pages Router hook that runs strictly at build time, stays out of the client bundle, and feeds identical values into HTML and hydration. The originating case is `pages/about/index.tsx` career years — see PR #104 and the fix in PR #105 for the full thread.
+
+For build-pipeline-level concerns around `output: 'export'` (where the output lands, `distDir` interaction, CI deployment), see [build-pipeline-gotchas.md](build-pipeline-gotchas.md).

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -5,17 +5,21 @@ import blogConfig from '../../config/blog.config'
 import { META_CONTENTS } from '../../config/meta-contents'
 import { CATEGORIES } from '../../config/posts.config'
 import TitleUtil from '../../utils/TitleUtil'
+import type { GetStaticProps } from 'next'
 
 const standardTimeout = 300
 const ratio = 1.5
 
 const CAREER_START_YEAR = 2015
-const CAREER_YEARS = new Date().getFullYear() - CAREER_START_YEAR
 const STACK = ['JavaScript', 'TypeScript', 'React', 'Next.js', 'Node.js', 'Web Component']
 const INTERESTS = ['DX', '웹 표준', 'Web Component', 'AI']
 const TOPICS = Object.values(CATEGORIES).join(', ')
 
-const About = () => {
+interface AboutProps {
+  careerYears: number
+}
+
+const About = ({ careerYears }: AboutProps) => {
   return (
     <>
       <CommonMeta
@@ -45,7 +49,7 @@ const About = () => {
             <strong>Frontend Engineer</strong>입니다.
           </p>
           <p>
-            {CAREER_START_YEAR}년부터 웹을 만들어 왔으며, 현재 {CAREER_YEARS}년차입니다.
+            {CAREER_START_YEAR}년부터 웹을 만들어 왔으며, 현재 {careerYears}년차입니다.
           </p>
           <p>주력 스택은 {STACK.join(', ')}입니다.</p>
           <p>주된 관심사는 {INTERESTS.join(', ')}입니다.</p>
@@ -68,6 +72,14 @@ const About = () => {
       <MainAdsBanner />
     </>
   )
+}
+
+export const getStaticProps: GetStaticProps<AboutProps> = async () => {
+  return {
+    props: {
+      careerYears: new Date().getFullYear() - CAREER_START_YEAR,
+    },
+  }
 }
 
 export default About

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -3,10 +3,17 @@ import CommonMeta from '../../components/common-meta/CommonMeta'
 import RaiseSection from '../../components/raise-section/RaiseSection'
 import blogConfig from '../../config/blog.config'
 import { META_CONTENTS } from '../../config/meta-contents'
+import { CATEGORIES } from '../../config/posts.config'
 import TitleUtil from '../../utils/TitleUtil'
 
 const standardTimeout = 300
 const ratio = 1.5
+
+const CAREER_START_YEAR = 2015
+const CAREER_YEARS = new Date().getFullYear() - CAREER_START_YEAR
+const STACK = ['JavaScript', 'TypeScript', 'React', 'Next.js', 'Node.js', 'Web Component']
+const INTERESTS = ['DX', '웹 표준', 'Web Component', 'AI']
+const TOPICS = Object.values(CATEGORIES).join(', ')
 
 const About = () => {
   return (
@@ -30,6 +37,24 @@ const About = () => {
           <p>
             <strong>정보 공유를 통해 저와 참여자 분들의 긍정적인 발전을 기원합니다.</strong>
           </p>
+        </RaiseSection>
+
+        <RaiseSection timeout={standardTimeout * ratio}>
+          <h2>About me</h2>
+          <p>
+            <strong>Frontend Engineer</strong>입니다.
+          </p>
+          <p>
+            {CAREER_START_YEAR}년부터 웹을 만들어 왔으며, 현재 {CAREER_YEARS}년차입니다.
+          </p>
+          <p>주력 스택은 {STACK.join(', ')}입니다.</p>
+          <p>주된 관심사는 {INTERESTS.join(', ')}입니다.</p>
+        </RaiseSection>
+
+        <RaiseSection timeout={standardTimeout * ratio * 2}>
+          <h2>About this blog</h2>
+          <p>학습한 내용을 기록하고 공유하기 위해 운영합니다.</p>
+          <p>주로 다루는 주제는 {TOPICS}입니다.</p>
         </RaiseSection>
 
         <RaiseSection timeout={standardTimeout * ratio * 3}>


### PR DESCRIPTION
## 요약
About 페이지에 운영자 소개와 블로그 정체성 섹션 두 개를 추가해 첫 방문자가 누가·어떤 주제를·왜 쓰는 블로그인지 빠르게 파악할 수 있게 한다. 개인정보 노출은 최소화하고(닉네임·실명·회사명 미노출), 경력 연차와 다루는 주제는 단일 소스로부터 자동 계산·생성하여 매년 수동 갱신이 필요 없도록 했다.

## 변경 사항
- \`pages/about/index.tsx\`: \`<RaiseSection>\` 두 개 추가 — \`About me\`, \`About this blog\`
- About me: 역할(Frontend Engineer) / 경력 연차(\`new Date().getFullYear() - 2015\`, 빌드 시점 기준) / 주력 스택(JS·TS·React·Next.js·Node.js·Web Component) / 관심 분야(DX·웹 표준·Web Component·AI)
- About this blog: \`config/posts.config.ts\`의 \`CATEGORIES\`를 \`Object.values().join(', ')\`로 단일 소스 노출 + 운영 동기 문장
- \`RaiseSection\` 등장 애니메이션: 기존 \`standardTimeout × ratio × N\` 패턴 유지(\`300 → 450 → 900 → 1350\`)
- 기존 \`Here is...\`·\`Licenses\` 섹션은 유지, Contact 섹션은 추가하지 않음

## 관련 이슈
Closes #103

## 테스트 체크리스트
- [ ] \`/about\` 진입 시 4개 섹션이 \`Here is...\` → \`About me\` → \`About this blog\` → \`Licenses\` 순서로 노출된다
- [ ] 페이지 진입 시 네 섹션이 \`timeout\` 간격(300/450/900/1350ms)으로 순차 fade-up 한다
- [ ] About me에 노출되는 연차가 \`현재 연도 - 2015\`와 일치한다 (2026년 빌드 → 11년차)
- [ ] About this blog의 카테고리 목록이 \`CATEGORIES\` 값(15개)과 일치한다
- [ ] 닉네임(Jay Lee)·실명·회사명이 페이지 어디에도 노출되지 않는다
- [ ] GitHub 등 외부 링크가 본문에 중복 노출되지 않는다 (기존 social 영역만 사용)
- [ ] 데스크톱(≥1280px) / 태블릿(800px) / 모바일(≤480px) 폭에서 레이아웃 깨짐 없음