### PR TITLE
fix(ads): guard AdSense push against narrow slot widths

### DIFF
--- a/.claude/docs/ads-adsense-rendering-gotchas.md
+++ b/.claude/docs/ads-adsense-rendering-gotchas.md
@@ -1,0 +1,43 @@
+# Ads / AdSense Rendering Gotchas
+
+Read this when: editing `GoogleAdsenseBanner`, `AsideAdsBanner`, `useIsMobile`, or the 3-column grid layout in `globals.css` / `pages/_app.tsx`.
+
+## Overview
+
+This page documents pitfalls in the AdSense ad rendering system and the `aside` column layout. Both are tightly coupled: the desktop grid determines how wide the aside cell is, and AdSense throws an unhandled exception when that width is insufficient.
+
+## Pitfalls
+
+### AdSense throws `TagError` when slot width < ~125 px — causing Next.js "Application error" fallback
+
+- **Symptom:** First-landing on any page (e.g. `/about`, `/{title}`) shows "Application error: a client-side exception has occurred" instead of content. Reloading usually recovers. Stack trace is entirely inside `adsbygoogle.js` with no React frames.
+- **Root cause:** `window.adsbygoogle.push({})` throws `TagError: No slot size for availableWidth=N` when the `<ins>` slot is narrower than ~125 px. Next.js 15 production mode treats any unhandled client-side throw as fatal and replaces the page with an error fallback.
+- **Fix:** `GoogleAdsenseBanner` MUST read `insRef.current.offsetWidth` before calling `push()`. If `offsetWidth < MIN_SLOT_WIDTH` (125), skip `push()` entirely. This is already implemented — do not remove this guard.
+
+### Aside cell collapses to ~30–70 px at viewport widths of ~860–1100 px
+
+- **Symptom:** The aside column appears nearly empty or too narrow to render ads.
+- **Root cause:** `#__next` uses `grid-template-columns: repeat(3, 1fr)` but `main` has a fixed `width: 768px`. The grid expands the main column to 768 px; the remaining space is split equally between the two flanking columns. At a 900 px viewport: aside ≈ (900 − 768) / 2 ≈ 66 px. At 1100 px: aside ≈ (1100 − 768) / 2 ≈ 166 px (safe).
+- **Rule:** NEVER lower `MOBILE_BREAKPOINT` in `hooks/useIsMobile.ts` below 1100 without verifying the aside cell width at the new threshold is ≥ 165 px (125 px slot + 40 px `p-wide` padding).
+
+### `useIsMobile` threshold (1100 px) does not match the CSS mobile breakpoint (800 px)
+
+- **Symptom:** `ContentExplorer` and `AsideAdsBanner` are absent at "clearly desktop" widths (e.g. 900–1099 px).
+- **Root cause:** The CSS `@media (max-width: 768px)` breakpoint controls grid layout collapse. The JS `useIsMobile` hook controls whether the aside's React subtree renders at all. These serve different purposes and MUST remain independent. The JS threshold (1100 px) is set to guarantee a safe aside cell width for ads, not to match the CSS layout breakpoint.
+- **Rule:** Do NOT assume `useIsMobile` means "phone-sized screen." It means "viewport too narrow for aside content to render safely." Keep both thresholds documented separately.
+
+### Push is called only once on mount — resizing the window does not re-trigger ads
+
+- **Symptom:** If a user loads the page at a narrow viewport (ads skipped), then widens the window, ads still don't appear until a full page reload.
+- **Root cause:** `useEffect` with `[]` runs once. Adding a ResizeObserver to re-push ads is out of scope and risks duplicate-push bugs. Reload-on-resize is acceptable given the target audience.
+- **Rule:** Do NOT add dynamic re-push logic without understanding AdSense's duplicate-push behavior. A single `push({})` per `<ins>` instance is the correct contract.
+
+## Conventions
+
+- `MIN_SLOT_WIDTH = 125` in `GoogleAdsenseBanner.tsx` — MUST NOT be lowered; 125 px is the empirically observed AdSense minimum for responsive ad slots.
+- `MOBILE_BREAKPOINT = 1100` in `hooks/useIsMobile.ts` — MUST NOT be lowered without recalculating aside cell width (formula: `(viewport − 768) / 2 ≥ MIN_SLOT_WIDTH + 40`).
+- The only caller of `useIsMobile` is `pages/_app.tsx`. Both the `AsideAdsBanner` and `ContentExplorer` render gates are controlled by the same `isMobile` value — changing the threshold affects both simultaneously.
+
+## Rationale
+
+The 3-column equal-fraction grid with a fixed-width main column is a legacy layout decision. Rather than refactoring the grid (high risk, wide blast radius), the safer fix was a JS-level render gate (`useIsMobile` threshold) backed by a component-level push guard (`MIN_SLOT_WIDTH`). The two layers are complementary: the threshold prevents rendering the aside entirely at unsafe widths, and the push guard is a last-resort safety net for any future caller that bypasses the render gate.

--- a/.claude/docs/index.md
+++ b/.claude/docs/index.md
@@ -10,3 +10,4 @@ Read this when: you need to find project knowledge documents written by AI agent
 | Why a lucide icon won't size via `font-size`, or where a brand icon went | [icon-library-gotchas.md](icon-library-gotchas.md) |
 | How to safely depend on dates, randomness, or other host-runtime values inside a page under `output: 'export'` | [static-export-rendering-gotchas.md](static-export-rendering-gotchas.md) |
 | How Tailwind v4 is set up here, and what classes/tokens MUST NOT be changed | [styling-gotchas.md](styling-gotchas.md) |
+| Why AdSense throws a fatal error at narrow viewports, and why `useIsMobile` threshold is 1100 px | [ads-adsense-rendering-gotchas.md](ads-adsense-rendering-gotchas.md) |

--- a/.claude/docs/styling-gotchas.md
+++ b/.claude/docs/styling-gotchas.md
@@ -57,6 +57,10 @@ The project styles itself with Tailwind CSS v4 in CSS-first mode (no `tailwind.c
 - `normalize.css` MUST NOT be reintroduced. If a preflight reset bites a new component (lists, headings, form controls), restore the affected user-agent default in `globals.css` `@layer base` and document it here.
 - The post-body article element MUST carry `prose max-w-none post-body` together (in that order is fine). `prose` provides the typography baseline; `.post-body` selectively overrides.
 
+## Related
+
+- [ads-adsense-rendering-gotchas.md](ads-adsense-rendering-gotchas.md) — pitfalls when the aside cell becomes too narrow for AdSense (ties into the `repeat(3, 1fr)` + fixed-width main grid behavior documented above).
+
 ## Rationale
 
 The migration to Tailwind v4 (issue #93) collapsed 30 `*.module.scss` files into Tailwind utilities to reduce cognitive overhead and enable token-based theming. CSS-first config was chosen over a JS config because v4's `@theme` directive removes the need for `tailwind.config.ts` and keeps tokens colocated with the rest of the global styles. `@tailwindcss/typography` was adopted to handle the markdown-rendered post body, where the HTML is `dangerouslySetInnerHTML`-injected and cannot receive utility classes element-by-element.

--- a/components/google-adsense/GoogleAdsenseBanner.tsx
+++ b/components/google-adsense/GoogleAdsenseBanner.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 export interface GoogleAdsenseBannerProps {
   adClient: string
@@ -11,14 +11,23 @@ declare global {
   }
 }
 
+// AdSense throws `TagError: No slot size for availableWidth=...` when the slot
+// is narrower than ~125px, which surfaces as a Next.js client-side exception
+// fallback. Skip push() entirely when the slot is too narrow.
+const MIN_SLOT_WIDTH = 125
+
 const GoogleAdsenseBanner = (props: GoogleAdsenseBannerProps) => {
+  const insRef = useRef<HTMLModElement>(null)
+
   useEffect(() => {
+    if (!insRef.current || insRef.current.offsetWidth < MIN_SLOT_WIDTH) return
     window.adsbygoogle = window.adsbygoogle || []
     window.adsbygoogle.push({})
   }, [])
 
   return (
     <ins
+      ref={insRef}
       className="adsbygoogle"
       style={{ display: 'block' }}
       data-ad-client={props.adClient}

--- a/hooks/useIsMobile.ts
+++ b/hooks/useIsMobile.ts
@@ -1,10 +1,16 @@
 import { useEffect, useState } from 'react'
 
+// Threshold derived from the desktop grid: main is fixed at 768px and aside
+// holds a 200px-max ad container. Below ~1100px the aside cell collapses to a
+// width where AdSense cannot render — treat that range as mobile so aside is
+// hidden via `pages/_app.tsx`'s `!isMobile` gate.
+const MOBILE_BREAKPOINT = 1100
+
 const useIsMobile = (initIsMobile: boolean) => {
   const [isMobile, setIsMobile] = useState<boolean>(initIsMobile)
 
   useEffect(() => {
-    setIsMobile(document.body.clientWidth <= 800)
+    setIsMobile(document.body.clientWidth <= MOBILE_BREAKPOINT)
   }, [])
 
   return isMobile


### PR DESCRIPTION
## 요약

좁은 데스크톱 뷰포트(≈860–900px)에서 grid 3-column 레이아웃의 aside 셀이 50–70px로 좁아져 AdSense가 TagError를 던지고, Next.js가 이를 client-side exception으로 처리해 "Application error" 페이지를 노출시키는 버그를 수정합니다.

## 변경 사항

- `GoogleAdsenseBanner`: `insRef.offsetWidth` 측정 후 125px 미만이면 `push()` 호출 생략 (모든 호출처에 일괄 적용)
- `useIsMobile`: 임계값 800 → 1100으로 상향 (aside 셀이 광고 + 패딩을 안전히 담을 수 있는 최소 폭 보장)
- 신규 문서 `ads-adsense-rendering-gotchas.md`: AdSense 슬롯 제약, grid 셀 폭 계산, 이중 threshold 의도 정리

## 관련 이슈

Closes #106

## 테스트 체크리스트

- [ ] 880px 뷰포트에서 `/about`, 포스트 페이지 첫 랜딩 시 "Application error" 미노출
- [ ] 880px 뷰포트에서 본문이 정상 렌더링
- [ ] 1200px 이상 뷰포트에서 aside 광고 정상 노출
- [ ] 800px 이하(모바일) 환경에서 aside 숨김 유지