### PR TITLE
feat(authoring): add dev-only Codex CLI post automation

### DIFF
--- a/.claude/docs/dev-authoring-pipeline.md
+++ b/.claude/docs/dev-authoring-pipeline.md
@@ -40,6 +40,12 @@ The dev authoring pipeline is a local-only UI (`/dev/authoring`) that calls the 
 - **Root cause**: `--output-schema` constrains Codex output at the model layer, but schema enforcement is probabilistic, not guaranteed.
 - **Rule**: `generate-post.dev.ts` MUST validate the response against the same JSON Schema defined in `utils/dev/types.ts` before returning data to the client. Do not remove or weaken this validation in the belief that `--output-schema` is sufficient.
 
+### Markdown HTML must be sanitized before `dangerouslySetInnerHTML`
+
+- **Symptom**: a malicious `<script>`, event handler, or `javascript:` URL in markdown body executes when the post renders.
+- **Root cause**: `marked()` passes raw HTML in markdown through unchanged. Codex output and user edits in the authoring page are untrusted inputs that share the same render path as production posts.
+- **Rule**: BOTH `utils/MarkdownUtil.ts` (production post render via `getStaticProps`) AND `pages/dev/authoring.dev.tsx` (dev preview) MUST run `DOMPurify.sanitize(marked(md))` before injecting into `dangerouslySetInnerHTML`. The `isomorphic-dompurify` package handles both Node and browser environments. NEVER inject `marked()` output directly.
+
 ### ThumbnailResolver path-traversal containment
 
 - **Symptom**: a crafted `thumbnailName` value could escape `public/assets/images/` and read or overwrite arbitrary files.

--- a/.claude/docs/dev-authoring-pipeline.md
+++ b/.claude/docs/dev-authoring-pipeline.md
@@ -1,0 +1,78 @@
+# Dev-Only Authoring Pipeline Gotchas
+
+Read this when: working on `pages/dev/`, `pages/api/dev/`, `utils/dev/`, `next.config.js` `pageExtensions`, or the Codex-backed post authoring flow.
+
+## Overview
+
+The dev authoring pipeline is a local-only UI (`/dev/authoring`) that calls the `codex` CLI to draft post content and then publishes it by mutating `config/posts.config.ts` and writing the markdown file. All pages and API routes participating in this flow use the `.dev.tsx` / `.dev.ts` suffix convention to be stripped from production builds.
+
+## Pitfalls
+
+### `pageExtensions` alone does NOT exclude `.dev.tsx` files from production
+
+- **Symptom**: a route like `/dev/authoring.dev` appears in the static export.
+- **Root cause**: `pageExtensions` filters which extensions Next.js recognizes as page files. Setting it to exclude `.dev.tsx` in production prevents the route from appearing at a clean URL — but Next.js still resolves the raw `*.dev.tsx` filename and can emit a page for it.
+- **Fix**: the `NormalModuleReplacementPlugin` in `next.config.js` swaps every `*.dev.tsx` / `*.dev.ts` module for an empty stub during production webpack compilation. This is the load-bearing exclusion. Both mechanisms must stay in place together.
+- **Belt-and-suspenders**: `getStaticProps` in `pages/dev/authoring.dev.tsx` returns `{ notFound: true }` when `NODE_ENV !== 'development'`, and the API routes return `405` for the same check. These guards catch the case where someone manually overrides `pageExtensions`.
+- **Artifact cleanup**: Next.js still creates an empty `./docs/dev/` directory during static export. The `docs` npm script runs `rm -rf ./docs/dev` after the build to remove it.
+
+### Category KEY vs VALUE — directory name != metadata value
+
+- **Symptom**: `PostConfigWriter` writes the wrong category string into `posts.config.ts`, causing a post to be invisible or mis-routed.
+- **Root cause**: `CATEGORIES` maps hyphenated keys to display values, e.g. `CATEGORIES['react-native'] === 'react native'`. The directory on disk uses the KEY (`posts/react-native/`), but the `category` field in the `Post` metadata stores the VALUE (`'react native'`).
+- **Fix**: `PostConfigWriter.getCategoryDir` reverses the map lookup to derive the correct directory from any given category value. NEVER write the category key directly into the metadata or the category value directly into the file path.
+
+### `posts.config.ts` string surgery requires a precise file tail
+
+- **Symptom**: `PostConfigWriter` throws at runtime with an assertion error, refusing to mutate the config.
+- **Root cause**: the writer appends to the `posts` array by locating the exact tail `]\n\nexport default posts\n`. If the file ends differently (trailing whitespace, different export style, extra blank lines), the assertion fails.
+- **Rule**: NEVER reformat the tail of `config/posts.config.ts` by hand or with a code formatter that changes that pattern. ALWAYS verify the assertion still holds after any manual edit to the file.
+
+### `codex` is a system binary, not an npm dependency
+
+- **Symptom**: `ENOENT` or "command not found" when the authoring API route spawns the Codex process.
+- **Root cause**: `CodexClient` calls `child_process.spawn('codex', ...)`. `codex` must be installed globally and on `$PATH` as a system binary. It is deliberately absent from `package.json`.
+- **Rule**: NEVER add `codex` as a project npm dependency. Before using the authoring page, run `codex login` once. Confirm it is reachable with `which codex`.
+
+### Codex output schema — Node-side validation is defense-in-depth, not optional
+
+- **Symptom**: downstream code receives a partial or malformed post draft and silently produces a broken `posts.config.ts` entry.
+- **Root cause**: `--output-schema` constrains Codex output at the model layer, but schema enforcement is probabilistic, not guaranteed.
+- **Rule**: `generate-post.dev.ts` MUST validate the response against the same JSON Schema defined in `utils/dev/types.ts` before returning data to the client. Do not remove or weaken this validation in the belief that `--output-schema` is sufficient.
+
+### ThumbnailResolver path-traversal containment
+
+- **Symptom**: a crafted `thumbnailName` value could escape `public/assets/images/` and read or overwrite arbitrary files.
+- **Root cause**: user-supplied thumbnail names are joined directly to the image directory path.
+- **Rule**: `ThumbnailResolver` MUST check that `path.resolve(imageDir, thumbnailName)` starts with `path.resolve(imageDir)` before accepting any path. NEVER bypass this check.
+
+## Conventions
+
+### File placement
+
+| Concern | Location |
+|---|---|
+| Dev-only pages | `pages/dev/*.dev.tsx` |
+| Dev-only API routes | `pages/api/dev/*.dev.ts` |
+| Server-only Node modules (dev) | `utils/dev/` |
+
+NEVER import anything from `utils/dev/` in a client component or non-dev page. These modules use `child_process` and other Node-only APIs that will break the client bundle.
+
+### Codex CLI invocation
+
+The canonical spawn arguments are:
+
+```
+codex exec --json --skip-git-repo-check --sandbox workspace-write --output-schema --output-last-message -
+```
+
+`--skip-git-repo-check` prevents Codex from failing when run outside a git repo root. `--sandbox workspace-write` restricts filesystem writes to the workspace. `--output-last-message` returns only the final model turn. NEVER omit `--json`; the response parser in `CodexClient` expects NDJSON.
+
+### Thumbnail v1 scope
+
+- `reuse`: the authoring page accepts an existing `thumbnailName`. `ThumbnailResolver` validates it exists under `public/assets/images/` (with path-traversal check).
+- `generate`: falls back to a manual file upload. Automatic image generation is deferred — do not add it without a separate design review.
+
+## Rationale
+
+The `.dev.tsx` / `.dev.ts` dual-mechanism approach (webpack plugin + `pageExtensions` + runtime `notFound`) was chosen because no single Next.js mechanism is sufficient to guarantee exclusion from a `output: 'export'` static build. The webpack plugin is the primary gate; the rest are belt-and-suspenders for defense-in-depth.

--- a/.claude/docs/dev-authoring-pipeline.md
+++ b/.claude/docs/dev-authoring-pipeline.md
@@ -8,6 +8,12 @@ The dev authoring pipeline is a local-only UI (`/dev/authoring`) that calls the 
 
 ## Pitfalls
 
+### `output: 'export'` must be production-only or dev breaks at startup
+
+- **Symptom**: `next dev` crashes immediately with `API Routes cannot be used with "output: export"`, blocking the whole dev server (not just the dev API routes).
+- **Root cause**: Next.js 15 enforces the `output: 'export'` / `pages/api/*` incompatibility at startup, before any build. Even though API routes never run during `next dev`, simply having `output: 'export'` set rejects the presence of any `pages/api/*` file.
+- **Rule**: `next.config.js` MUST set `output: 'export'` only when `NODE_ENV === 'production'` (see the `isDev` ternary at the top of the file). `pnpm run build` and `pnpm run docs` run under `NODE_ENV=production` and still emit the static export. NEVER set `output: 'export'` unconditionally as long as `pages/api/dev/*` exists.
+
 ### `pageExtensions` alone does NOT exclude `.dev.tsx` files from production
 
 - **Symptom**: a route like `/dev/authoring.dev` appears in the static export.

--- a/.claude/docs/index.md
+++ b/.claude/docs/index.md
@@ -11,3 +11,4 @@ Read this when: you need to find project knowledge documents written by AI agent
 | How to safely depend on dates, randomness, or other host-runtime values inside a page under `output: 'export'` | [static-export-rendering-gotchas.md](static-export-rendering-gotchas.md) |
 | How Tailwind v4 is set up here, and what classes/tokens MUST NOT be changed | [styling-gotchas.md](styling-gotchas.md) |
 | Why AdSense throws a fatal error at narrow viewports, and why `useIsMobile` threshold is 1100 px | [ads-adsense-rendering-gotchas.md](ads-adsense-rendering-gotchas.md) |
+| How the dev-only Codex authoring page works, why `pageExtensions` alone isn't enough, and what MUST NOT change | [dev-authoring-pipeline.md](dev-authoring-pipeline.md) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Always invoke scripts as `pnpm run <script>` — bare `pnpm <script>` collides w
 
 - `pnpm dev` — Next.js dev server (http://localhost:3000)
 - `pnpm run build` — Next.js production build (writes static export to `./out` because `output: 'export'` is set in `next.config.js`)
-- `pnpm run docs` — full static export pipeline used by CI: cleans, builds, moves `./out` → `./docs`, drops `.nojekyll`, then runs `pnpm run sitemap`. The `./docs` directory is what GitHub Pages serves, so it is committed to `main` (by CI, not by hand — see Deployment).
+- `pnpm run docs` — full static export pipeline used by CI: cleans, builds, moves `./out` → `./docs`, drops `.nojekyll`, removes the empty `./docs/dev/` artifact left by dev-only pages (see Dev-only convention below), then runs `pnpm run sitemap`. The `./docs` directory is what GitHub Pages serves, so it is committed to `main` (by CI, not by hand — see Deployment).
 - `pnpm run sitemap` — runs `bin/generate-sitemap.ts` against the just-built `./docs` directory; will fail if `./docs` is empty.
 - `pnpm run licenses` — regenerates `public/licenses.json` (consumed by `/licenses` page) using `license-checker-rseidelsohn`.
 - `pnpm run lint` — ESLint CLI (`eslint .`) configured via `eslint.config.mjs` (flat config). Uses `FlatCompat` to bring in `next/core-web-vitals` since `eslint-config-next@15` still ships as legacy eslintrc; `@next/next/no-img-element` is intentionally disabled — native `<img>` is allowed. Build outputs (`.next/`, `out/`, `docs/`, `public/`) are ignored.
@@ -68,3 +68,7 @@ Build-time flow:
 ### Assets
 
 Post thumbnails and inline markdown images are served from `public/assets/images/` and referenced by `thumbnailName` (just the filename — `PathUtil.buildImagePath` prefixes the directory).
+
+### Dev-only pages and API routes (`.dev.tsx` / `.dev.ts` convention)
+
+`pages/dev/*.dev.tsx`, `pages/api/dev/*.dev.ts`, and `utils/dev/*` are excluded from the static export via a multi-layer mechanism. The `/dev/authoring` page requires the locally-installed `codex` CLI on `$PATH`. For the full isolation mechanism, file placement rules, and pitfalls, see [.claude/docs/dev-authoring-pipeline.md](.claude/docs/dev-authoring-pipeline.md).

--- a/components/google-adsense/GoogleAdsenseBanner.tsx
+++ b/components/google-adsense/GoogleAdsenseBanner.tsx
@@ -20,11 +20,15 @@ const GoogleAdsenseBanner = (props: GoogleAdsenseBannerProps) => {
   const insRef = useRef<HTMLModElement>(null)
 
   useEffect(() => {
-    if (process.env.NODE_ENV !== 'production') return
     if (!insRef.current || insRef.current.offsetWidth < MIN_SLOT_WIDTH) return
     window.adsbygoogle = window.adsbygoogle || []
     window.adsbygoogle.push({})
   }, [])
+
+  // AdSense auto-discovers `<ins class="adsbygoogle" data-ad-client="...">`
+  // elements and fetches ads from doubleclick.net regardless of whether we
+  // call push(). Render nothing in dev so the slot leaves no trace.
+  if (process.env.NODE_ENV !== 'production') return null
 
   return (
     <ins

--- a/components/google-adsense/GoogleAdsenseBanner.tsx
+++ b/components/google-adsense/GoogleAdsenseBanner.tsx
@@ -20,6 +20,7 @@ const GoogleAdsenseBanner = (props: GoogleAdsenseBannerProps) => {
   const insRef = useRef<HTMLModElement>(null)
 
   useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') return
     if (!insRef.current || insRef.current.offsetWidth < MIN_SLOT_WIDTH) return
     window.adsbygoogle = window.adsbygoogle || []
     window.adsbygoogle.push({})

--- a/config/menu.config.ts
+++ b/config/menu.config.ts
@@ -4,6 +4,9 @@ const menus: Menu[] = [
   { display: 'Home', route: '/' },
   { display: 'Posts', route: '/posts/1' },
   { display: 'About', route: '/about' },
+  ...(process.env.NODE_ENV !== 'production'
+    ? [{ display: 'Authoring (dev)', route: '/dev/authoring' }]
+    : []),
 ]
 
 export default menus

--- a/hooks/useAdsense.ts
+++ b/hooks/useAdsense.ts
@@ -3,6 +3,7 @@ import blogConfig from '../config/blog.config'
 
 const useAdsense = (adClient: typeof blogConfig.googleAdsense.adClient) => {
   useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') return
     if (document.head) {
       const script = document.createElement('script')
       script.async = true

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,48 @@
 /** @type {import('next').NextConfig} */
+const isDev = process.env.NODE_ENV !== 'production'
+
+// .dev.tsx / .dev.ts files are only resolved as pages in dev mode.
+// This is the load-bearing mechanism that keeps dev-only pages and API routes
+// (pages/dev/*.dev.tsx, pages/api/dev/*.dev.ts) out of the static export.
+//
+// How it works:
+//   - In dev: pageExtensions starts with 'dev.tsx'/'dev.ts' — Next.js strips
+//     the FIRST matching extension, so `authoring.dev.tsx` → route `/dev/authoring`.
+//   - In prod: 'dev.tsx'/'dev.ts' are absent from the list, so files ending in
+//     `.dev.tsx` fall through to `tsx` and become routes like `/dev/authoring.dev`.
+//     The webpack NormalModuleReplacementPlugin then replaces those files with an
+//     empty module, effectively making Next.js see empty pages it can't export.
+//
+// The combination of:
+//   1. pageExtensions (dev route naming),
+//   2. NormalModuleReplacementPlugin (prod file exclusion), and
+//   3. getStaticProps returning notFound:true (belt-and-suspenders)
+// ensures .dev files never appear in the static export.
+const pageExtensions = isDev
+  ? ['dev.tsx', 'dev.ts', 'tsx', 'ts', 'jsx', 'js']
+  : ['tsx', 'ts', 'jsx', 'js']
+
+/** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   output: 'export',
+  pageExtensions,
+  webpack(config, { isServer }) {
+    if (!isDev) {
+      // In production builds, replace any *.dev.tsx / *.dev.ts file with an
+      // empty module so Next.js does not attempt to render or export it.
+      // This is belt-and-suspenders alongside the pageExtensions filter and
+      // the getStaticProps notFound guard inside each dev page.
+      const { NormalModuleReplacementPlugin } = require('webpack')
+      config.plugins.push(
+        new NormalModuleReplacementPlugin(
+          /\.dev\.(tsx?|jsx?)$/,
+          require.resolve('./utils/dev/_empty-module.js')
+        )
+      )
+    }
+    return config
+  },
 }
 
 module.exports = nextConfig

--- a/next.config.js
+++ b/next.config.js
@@ -25,7 +25,12 @@ const pageExtensions = isDev
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  output: 'export',
+  // `output: 'export'` rejects any pages/api/* file at startup — including in
+  // dev mode (Next.js 15 enforces this even before `next build`). The dev-only
+  // API routes under pages/api/dev/*.dev.ts need to run, so apply the static
+  // export only in production. `pnpm run build` / `pnpm run docs` run with
+  // NODE_ENV=production and still produce the static export as before.
+  ...(isDev ? {} : { output: 'export' }),
   pageExtensions,
   webpack(config, { isServer }) {
     if (!isDev) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "next dev",
     "build": "next build",
     "docs:clean": "rm -rf ./docs ./out",
-    "docs": "pnpm run docs:clean && pnpm run build && mv ./out ./docs && touch ./docs/.nojekyll && pnpm run sitemap",
+    "docs": "pnpm run docs:clean && pnpm run build && mv ./out ./docs && touch ./docs/.nojekyll && rm -rf ./docs/dev && pnpm run sitemap",
     "start": "next start",
     "lint": "eslint .",
     "prepare": "husky",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "highlight.js": "^11.11.1",
+    "isomorphic-dompurify": "^3.12.0",
     "lucide-react": "^1.14.0",
     "next": "^15.5.18",
     "react": "^19.2.6",

--- a/pages/api/dev/generate-post.dev.ts
+++ b/pages/api/dev/generate-post.dev.ts
@@ -1,0 +1,109 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import postsDatabase from '../../../database/post-database'
+import { buildAuthoringPrompt, getSchemaFilePath } from '../../../utils/dev/AuthoringPrompt'
+import { runCodex } from '../../../utils/dev/CodexClient'
+import { listThumbnailFiles } from '../../../utils/dev/ThumbnailResolver'
+import { CATEGORIES } from '../../../config/posts.config'
+import { GeneratedPost } from '../../../utils/dev/types'
+
+// Belt-and-suspenders: also blocked at pageExtensions layer in production
+if (process.env.NODE_ENV === 'production') {
+  console.warn('generate-post.dev.ts loaded in production — this should not happen')
+}
+
+type SuccessResponse = { post: GeneratedPost }
+type ErrorResponse = { error: string; detail?: string }
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<SuccessResponse | ErrorResponse>
+) {
+  // Production guard
+  if (process.env.NODE_ENV === 'production') {
+    return res.status(404).end()
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { userInstruction } = req.body as { userInstruction?: string }
+  if (!userInstruction || typeof userInstruction !== 'string' || !userInstruction.trim()) {
+    return res.status(400).json({ error: 'userInstruction is required' })
+  }
+
+  // Compute today in local time (YYYY-MM-DD)
+  const today = new Date().toLocaleDateString('sv-SE') // 'sv-SE' gives YYYY-MM-DD in local TZ
+
+  const publishedPosts = postsDatabase.find()
+  const thumbnailFileNames = listThumbnailFiles()
+  const schemaPath = getSchemaFilePath()
+
+  const prompt = buildAuthoringPrompt({
+    userInstruction: userInstruction.trim(),
+    today,
+    publishedPosts,
+    thumbnailFileNames,
+  })
+
+  let rawOutput: string
+  try {
+    rawOutput = await runCodex({ prompt, schemaPath, timeoutMs: 300_000 })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return res.status(500).json({
+      error: 'codex execution failed',
+      detail: message,
+    })
+  }
+
+  // Parse and validate the JSON output
+  let post: GeneratedPost
+  try {
+    post = JSON.parse(rawOutput) as GeneratedPost
+  } catch {
+    return res.status(500).json({
+      error: 'codex returned invalid JSON',
+      detail: rawOutput.slice(0, 500),
+    })
+  }
+
+  // Defense-in-depth validation
+  const validationError = validateGeneratedPost(post)
+  if (validationError) {
+    return res.status(500).json({ error: validationError, detail: rawOutput.slice(0, 500) })
+  }
+
+  return res.status(200).json({ post })
+}
+
+function validateGeneratedPost(post: GeneratedPost): string | null {
+  if (!post || typeof post !== 'object') return 'Response is not an object'
+
+  const { metadata, markdown, thumbnail } = post
+
+  if (!metadata) return 'Missing metadata'
+  if (!markdown || typeof markdown !== 'string') return 'Missing or invalid markdown'
+  if (!thumbnail) return 'Missing thumbnail'
+
+  if (!(metadata.category in CATEGORIES)) {
+    return `Invalid category key: "${metadata.category}"`
+  }
+  if (!metadata.fileName || !/^[a-z0-9-]+\.md$/.test(metadata.fileName)) {
+    return `Invalid fileName: "${metadata.fileName}" (must be kebab-case ending in .md)`
+  }
+  if (!metadata.publishedAt || !/^\d{4}-\d{2}-\d{2}$/.test(metadata.publishedAt)) {
+    return `Invalid publishedAt: "${metadata.publishedAt}" (must be YYYY-MM-DD)`
+  }
+  if (!Array.isArray(metadata.tags) || metadata.tags.length === 0) {
+    return 'tags must be a non-empty array'
+  }
+  if (!thumbnail.mode || !['reuse', 'generate'].includes(thumbnail.mode)) {
+    return 'thumbnail.mode must be "reuse" or "generate"'
+  }
+  if (thumbnail.mode === 'reuse' && !thumbnail.reuseFileName) {
+    return 'thumbnail.mode is "reuse" but reuseFileName is missing'
+  }
+
+  return null
+}

--- a/pages/api/dev/publish-post.dev.ts
+++ b/pages/api/dev/publish-post.dev.ts
@@ -1,0 +1,147 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import fs from 'fs'
+import path from 'path'
+import { CATEGORIES } from '../../../config/posts.config'
+import { appendPostConfig, getCategoryDir } from '../../../utils/dev/PostConfigWriter'
+import { resolveThumbnail } from '../../../utils/dev/ThumbnailResolver'
+import { GeneratedPost } from '../../../utils/dev/types'
+import PostUtil from '../../../utils/PostUtil'
+
+if (process.env.NODE_ENV === 'production') {
+  console.warn('publish-post.dev.ts loaded in production — this should not happen')
+}
+
+type SuccessResponse = { url: string; message: string }
+type ErrorResponse = { error: string }
+
+// Increase body size limit for base64-encoded thumbnail uploads
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '10mb',
+    },
+  },
+}
+
+interface PublishRequestBody {
+  post: GeneratedPost
+  /** Base64-encoded image data (only when thumbnail.mode === 'generate') */
+  thumbnailBase64?: string
+  /** Original MIME type of uploaded image (e.g. 'image/png') */
+  thumbnailMimeType?: string
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<SuccessResponse | ErrorResponse>
+) {
+  if (process.env.NODE_ENV === 'production') {
+    return res.status(404).end()
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { post, thumbnailBase64, thumbnailMimeType } = req.body as PublishRequestBody
+
+  if (!post || !post.metadata || !post.markdown || !post.thumbnail) {
+    return res.status(400).json({ error: 'Invalid request body: post, metadata, markdown, and thumbnail are required' })
+  }
+
+  const { metadata, markdown, thumbnail } = post
+
+  // Validate category
+  if (!(metadata.category in CATEGORIES)) {
+    return res.status(400).json({ error: `Invalid category key: "${metadata.category}"` })
+  }
+
+  // Validate fileName format
+  if (!metadata.fileName || !/^[a-z0-9-]+\.md$/.test(metadata.fileName)) {
+    return res.status(400).json({ error: `Invalid fileName: "${metadata.fileName}"` })
+  }
+
+  const categoryDir = getCategoryDir(metadata.category)
+  const markdownDir = path.join(process.cwd(), 'posts', categoryDir)
+  const markdownPath = path.join(markdownDir, metadata.fileName)
+
+  // Collision check: file must not exist on disk
+  if (fs.existsSync(markdownPath)) {
+    return res.status(409).json({
+      error: `File already exists: posts/${categoryDir}/${metadata.fileName}. Choose a different fileName.`,
+    })
+  }
+
+  // Resolve thumbnail
+  let thumbnailName: string
+  let resolvedThumbnailPath: string | undefined
+  try {
+    let uploadedImageBuffer: Buffer | undefined
+    let targetFileName: string | undefined
+
+    if (thumbnail.mode === 'generate') {
+      if (!thumbnailBase64 || !thumbnailMimeType) {
+        return res.status(400).json({
+          error: 'thumbnail.mode is "generate" but no image was uploaded. Provide thumbnailBase64 and thumbnailMimeType.',
+        })
+      }
+      uploadedImageBuffer = Buffer.from(thumbnailBase64, 'base64')
+      const ext = mimeToExt(thumbnailMimeType)
+      // Derive filename from post slug
+      const slug = metadata.fileName.replace(/\.md$/, '')
+      targetFileName = `${slug}.${ext}`
+    }
+
+    thumbnailName = resolveThumbnail(thumbnail, { uploadedImageBuffer, targetFileName })
+    // Track the resolved thumbnail path only for generated thumbnails so we can
+    // roll it back if a later step fails (reused thumbnails pre-existed and must
+    // not be deleted on rollback).
+    if (thumbnail.mode === 'generate') {
+      resolvedThumbnailPath = path.join(process.cwd(), 'public', 'assets', 'images', thumbnailName)
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return res.status(400).json({ error: message })
+  }
+
+  // Write markdown file
+  try {
+    fs.mkdirSync(markdownDir, { recursive: true })
+    fs.writeFileSync(markdownPath, markdown, 'utf8')
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return res.status(500).json({ error: `Failed to write markdown: ${message}` })
+  }
+
+  // Append to posts.config.ts
+  try {
+    appendPostConfig(metadata, thumbnailName)
+  } catch (err) {
+    // Roll back the markdown file we just wrote
+    try { fs.unlinkSync(markdownPath) } catch { /* ignore */ }
+    // Roll back the generated thumbnail (only if we created it — never delete reused ones)
+    if (resolvedThumbnailPath) {
+      try { fs.unlinkSync(resolvedThumbnailPath) } catch { /* ignore */ }
+    }
+    const message = err instanceof Error ? err.message : String(err)
+    return res.status(500).json({ error: `Failed to update posts.config.ts: ${message}` })
+  }
+
+  const url = '/' + PostUtil.normalizeTitle(metadata.title)
+  return res.status(200).json({
+    url,
+    message: `Post published! Visit ${url} in dev to preview.`,
+  })
+}
+
+function mimeToExt(mime: string): string {
+  const map: Record<string, string> = {
+    'image/png': 'png',
+    'image/jpeg': 'jpg',
+    'image/jpg': 'jpg',
+    'image/webp': 'webp',
+    'image/gif': 'gif',
+    'image/svg+xml': 'svg',
+  }
+  return map[mime] ?? 'png'
+}

--- a/pages/dev/authoring.dev.tsx
+++ b/pages/dev/authoring.dev.tsx
@@ -1,4 +1,5 @@
 import type { GetStaticProps, NextPage } from 'next'
+import DOMPurify from 'isomorphic-dompurify'
 import { marked } from 'marked'
 import hljs from 'highlight.js'
 import { ChangeEvent, ReactElement, useEffect, useRef, useState } from 'react'
@@ -69,7 +70,7 @@ const AuthoringPage: NextPage = (): ReactElement => {
   // ── Sync markdown preview ──────────────────────────────────────────────
   useEffect(() => {
     if (!markdown) { setRenderedHtml(''); return }
-    setRenderedHtml(marked(markdown) as string)
+    setRenderedHtml(DOMPurify.sanitize(marked(markdown) as string))
   }, [markdown])
 
   useEffect(() => {

--- a/pages/dev/authoring.dev.tsx
+++ b/pages/dev/authoring.dev.tsx
@@ -1,0 +1,428 @@
+import type { GetStaticProps, NextPage } from 'next'
+import { marked } from 'marked'
+import hljs from 'highlight.js'
+import { ChangeEvent, ReactElement, useEffect, useRef, useState } from 'react'
+import { CATEGORIES } from '../../config/posts.config'
+import { GeneratedPost, GeneratedPostMetadata } from '../../utils/dev/types'
+
+// Production guard — belt-and-suspenders alongside pageExtensions filtering.
+export const getStaticProps: GetStaticProps = async () => {
+  if (process.env.NODE_ENV === 'production') return { notFound: true }
+  return { props: {} }
+}
+
+type Stage = 'input' | 'generating' | 'preview' | 'publishing' | 'done'
+
+const AuthoringPage: NextPage = (): ReactElement => {
+  // ── Input ──────────────────────────────────────────────────────────────
+  const [instruction, setInstruction] = useState('')
+
+  // ── Generation state ───────────────────────────────────────────────────
+  const [stage, setStage] = useState<Stage>('input')
+  const [elapsedSeconds, setElapsedSeconds] = useState(0)
+  const [generateError, setGenerateError] = useState('')
+
+  // ── Generated post (editable) ──────────────────────────────────────────
+  const [post, setPost] = useState<GeneratedPost | null>(null)
+  // Editable metadata fields
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [category, setCategory] = useState<keyof typeof CATEGORIES>('javascript')
+  const [fileName, setFileName] = useState('')
+  const [publishedAt, setPublishedAt] = useState('')
+  const [tagsInput, setTagsInput] = useState('')
+  const [refsInput, setRefsInput] = useState('') // JSON array string
+  const [markdown, setMarkdown] = useState('')
+
+  // ── Thumbnail ──────────────────────────────────────────────────────────
+  const [thumbnailMode, setThumbnailMode] = useState<'reuse' | 'generate'>('reuse')
+  const [reuseFileName, setReuseFileName] = useState('')
+  const [generatePrompt, setGeneratePrompt] = useState('')
+  const [uploadedFile, setUploadedFile] = useState<File | null>(null)
+  const [uploadedBase64, setUploadedBase64] = useState('')
+
+  // ── Preview ────────────────────────────────────────────────────────────
+  const [renderedHtml, setRenderedHtml] = useState('')
+  const previewRef = useRef<HTMLDivElement>(null)
+
+  // ── Publish ────────────────────────────────────────────────────────────
+  const [publishError, setPublishError] = useState('')
+  const [publishedUrl, setPublishedUrl] = useState('')
+
+  // ── Elapsed timer ──────────────────────────────────────────────────────
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  function startTimer() {
+    setElapsedSeconds(0)
+    timerRef.current = setInterval(() => {
+      setElapsedSeconds((s) => s + 1)
+    }, 1000)
+  }
+  function stopTimer() {
+    if (timerRef.current) {
+      clearInterval(timerRef.current)
+      timerRef.current = null
+    }
+  }
+  useEffect(() => () => stopTimer(), [])
+
+  // ── Sync markdown preview ──────────────────────────────────────────────
+  useEffect(() => {
+    if (!markdown) { setRenderedHtml(''); return }
+    setRenderedHtml(marked(markdown) as string)
+  }, [markdown])
+
+  useEffect(() => {
+    if (stage === 'preview' && previewRef.current) {
+      hljs.highlightAll()
+    }
+  }, [stage, renderedHtml])
+
+  // ── Populate editable fields from generated post ───────────────────────
+  function populateFromPost(generated: GeneratedPost) {
+    setPost(generated)
+    const m = generated.metadata
+    setTitle(m.title)
+    setDescription(m.description)
+    setCategory(m.category)
+    setFileName(m.fileName)
+    setPublishedAt(m.publishedAt)
+    setTagsInput(m.tags.join(', '))
+    setRefsInput(m.references ? JSON.stringify(m.references, null, 2) : '')
+    setMarkdown(generated.markdown)
+    setThumbnailMode(generated.thumbnail.mode)
+    setReuseFileName(generated.thumbnail.reuseFileName ?? '')
+    setGeneratePrompt(generated.thumbnail.generatePrompt ?? '')
+  }
+
+  // ── Generate handler ───────────────────────────────────────────────────
+  async function handleGenerate() {
+    if (!instruction.trim()) return
+    setGenerateError('')
+    setPublishError('')
+    setPublishedUrl('')
+    setStage('generating')
+    startTimer()
+
+    try {
+      const res = await fetch('/api/dev/generate-post', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userInstruction: instruction }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setGenerateError(data.error + (data.detail ? `\n\n${data.detail}` : ''))
+        setStage('input')
+        return
+      }
+      populateFromPost(data.post as GeneratedPost)
+      setStage('preview')
+    } catch (err) {
+      setGenerateError(err instanceof Error ? err.message : String(err))
+      setStage('input')
+    } finally {
+      stopTimer()
+    }
+  }
+
+  // ── File upload handler ────────────────────────────────────────────────
+  function handleFileChange(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setUploadedFile(file)
+    const reader = new FileReader()
+    reader.onload = (ev) => {
+      const result = ev.target?.result as string
+      // result is data:image/png;base64,XXXX — strip prefix
+      const base64 = result.split(',')[1]
+      setUploadedBase64(base64)
+    }
+    reader.readAsDataURL(file)
+  }
+
+  // ── Build metadata from editable fields ───────────────────────────────
+  function buildMetadata(): GeneratedPostMetadata {
+    let refs: { title: string; url: string }[] | undefined
+    if (refsInput.trim()) {
+      try {
+        refs = JSON.parse(refsInput)
+      } catch {
+        refs = undefined
+      }
+    }
+    return {
+      title,
+      description,
+      category,
+      fileName,
+      publishedAt,
+      tags: tagsInput.split(',').map((t) => t.trim()).filter(Boolean),
+      references: refs,
+    }
+  }
+
+  // ── Publish handler ────────────────────────────────────────────────────
+  async function handlePublish() {
+    setPublishError('')
+    setStage('publishing')
+
+    const updatedPost: GeneratedPost = {
+      ...post!,
+      metadata: buildMetadata(),
+      markdown,
+      thumbnail: {
+        mode: thumbnailMode,
+        reuseFileName: thumbnailMode === 'reuse' ? reuseFileName : undefined,
+        generatePrompt: thumbnailMode === 'generate' ? generatePrompt : undefined,
+      },
+    }
+
+    const body: Record<string, unknown> = { post: updatedPost }
+    if (thumbnailMode === 'generate') {
+      if (!uploadedBase64) {
+        setPublishError('썸네일 이미지를 업로드해 주세요.')
+        setStage('preview')
+        return
+      }
+      body.thumbnailBase64 = uploadedBase64
+      body.thumbnailMimeType = uploadedFile?.type ?? 'image/png'
+    }
+
+    try {
+      const res = await fetch('/api/dev/publish-post', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setPublishError(data.error)
+        setStage('preview')
+        return
+      }
+      setPublishedUrl(data.url)
+      setStage('done')
+    } catch (err) {
+      setPublishError(err instanceof Error ? err.message : String(err))
+      setStage('preview')
+    }
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────
+  return (
+    <div className="max-w-4xl mx-auto p-6 space-y-8">
+      {/* Header */}
+      <div className="border-b pb-4">
+        <h1 className="text-2xl font-bold">글 작성 (Dev only)</h1>
+        <p className="text-sm text-gray-500 mt-1">이 페이지는 production export에 포함되지 않습니다.</p>
+      </div>
+
+      {/* Section A — Input */}
+      {(stage === 'input' || stage === 'generating') && (
+        <div className="space-y-4">
+          <label className="block font-semibold" htmlFor="instruction">
+            작성 지시
+          </label>
+          <textarea
+            id="instruction"
+            className="w-full border rounded p-3 font-mono text-sm h-36 resize-y"
+            placeholder="예: React 19의 useActionState 사용법 정리"
+            value={instruction}
+            onChange={(e) => setInstruction(e.target.value)}
+            disabled={stage === 'generating'}
+          />
+          {generateError && (
+            <pre className="bg-red-50 text-red-700 p-3 rounded text-sm whitespace-pre-wrap overflow-auto">
+              {generateError}
+            </pre>
+          )}
+          <button
+            onClick={handleGenerate}
+            disabled={stage === 'generating' || !instruction.trim()}
+            className="px-6 py-2 bg-blue-600 text-white rounded disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+          >
+            {stage === 'generating' ? '생성 중...' : '생성'}
+          </button>
+        </div>
+      )}
+
+      {/* Section B — Generating spinner */}
+      {stage === 'generating' && (
+        <div className="flex items-center gap-4 text-gray-600">
+          <div className="w-6 h-6 border-4 border-blue-400 border-t-transparent rounded-full animate-spin" />
+          <span>Codex가 포스트를 작성하는 중입니다… ({elapsedSeconds}초)</span>
+        </div>
+      )}
+
+      {/* Section C — Preview */}
+      {(stage === 'preview' || stage === 'publishing' || stage === 'done') && (
+        <div className="space-y-8">
+          {/* Back button */}
+          {stage === 'preview' && (
+            <button
+              onClick={() => setStage('input')}
+              className="text-sm text-blue-600 underline cursor-pointer"
+            >
+              ← 다시 작성
+            </button>
+          )}
+
+          {/* Metadata editor */}
+          <details open className="border rounded p-4 space-y-4">
+            <summary className="font-semibold cursor-pointer">메타데이터 편집</summary>
+            <div className="space-y-3 mt-3">
+              <Field label="제목">
+                <input className="w-full border rounded p-2 text-sm" value={title} onChange={(e) => setTitle(e.target.value)} />
+              </Field>
+              <Field label="설명">
+                <textarea className="w-full border rounded p-2 text-sm h-20 resize-y" value={description} onChange={(e) => setDescription(e.target.value)} />
+              </Field>
+              <Field label="카테고리">
+                <select
+                  className="border rounded p-2 text-sm"
+                  value={category}
+                  onChange={(e) => setCategory(e.target.value as keyof typeof CATEGORIES)}
+                >
+                  {Object.entries(CATEGORIES).map(([key, val]) => (
+                    <option key={key} value={key}>{key} — {val}</option>
+                  ))}
+                </select>
+              </Field>
+              <Field label="fileName">
+                <input className="w-full border rounded p-2 text-sm font-mono" value={fileName} onChange={(e) => setFileName(e.target.value)} />
+              </Field>
+              <Field label="publishedAt">
+                <input type="date" className="border rounded p-2 text-sm" value={publishedAt} onChange={(e) => setPublishedAt(e.target.value)} />
+              </Field>
+              <Field label="태그 (쉼표 구분)">
+                <input className="w-full border rounded p-2 text-sm" value={tagsInput} onChange={(e) => setTagsInput(e.target.value)} />
+              </Field>
+              <Field label="references (JSON 배열)">
+                <textarea
+                  className="w-full border rounded p-2 text-sm font-mono h-28 resize-y"
+                  value={refsInput}
+                  onChange={(e) => setRefsInput(e.target.value)}
+                  placeholder='[{"title":"...", "url":"..."}]'
+                />
+              </Field>
+            </div>
+          </details>
+
+          {/* Thumbnail */}
+          <details open className="border rounded p-4 space-y-4">
+            <summary className="font-semibold cursor-pointer">썸네일</summary>
+            <div className="mt-3 space-y-3">
+              <div className="flex gap-4 items-center">
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input type="radio" value="reuse" checked={thumbnailMode === 'reuse'} onChange={() => setThumbnailMode('reuse')} />
+                  기존 파일 재사용
+                </label>
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input type="radio" value="generate" checked={thumbnailMode === 'generate'} onChange={() => setThumbnailMode('generate')} />
+                  이미지 업로드 (직접 제공)
+                </label>
+              </div>
+              {thumbnailMode === 'reuse' && (
+                <div className="space-y-2">
+                  <input
+                    className="w-full border rounded p-2 text-sm"
+                    value={reuseFileName}
+                    onChange={(e) => setReuseFileName(e.target.value)}
+                    placeholder="예: react-thumbnail.png"
+                  />
+                  {reuseFileName && (
+                    <img
+                      src={`/assets/images/${reuseFileName}`}
+                      alt="thumbnail preview"
+                      className="h-32 object-contain border rounded"
+                    />
+                  )}
+                </div>
+              )}
+              {thumbnailMode === 'generate' && (
+                <div className="space-y-2">
+                  <p className="text-sm text-gray-600">Codex 제안 프롬프트: <em>{generatePrompt}</em></p>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    onChange={handleFileChange}
+                    className="text-sm"
+                  />
+                  {uploadedFile && (
+                    <p className="text-xs text-gray-500">{uploadedFile.name} ({Math.round(uploadedFile.size / 1024)}KB) 선택됨</p>
+                  )}
+                </div>
+              )}
+            </div>
+          </details>
+
+          {/* Markdown editor + preview */}
+          <div className="space-y-4">
+            <h2 className="font-semibold">본문 편집</h2>
+            <textarea
+              className="w-full border rounded p-3 font-mono text-sm h-64 resize-y"
+              value={markdown}
+              onChange={(e) => setMarkdown(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <h2 className="font-semibold">미리보기</h2>
+            <div
+              ref={previewRef}
+              className="prose max-w-none post-body border rounded p-4"
+              dangerouslySetInnerHTML={{ __html: renderedHtml }}
+            />
+          </div>
+
+          {/* Errors & publish */}
+          {publishError && (
+            <pre className="bg-red-50 text-red-700 p-3 rounded text-sm whitespace-pre-wrap overflow-auto">
+              {publishError}
+            </pre>
+          )}
+
+          {stage === 'done' && publishedUrl && (
+            <div className="bg-green-50 text-green-800 p-4 rounded">
+              <p className="font-semibold">게시 완료!</p>
+              <p className="text-sm mt-1">
+                <a href={publishedUrl} className="underline">{publishedUrl}</a> 에서 확인하세요.
+              </p>
+              <p className="text-xs text-gray-500 mt-2">
+                변경 사항을 커밋해 주세요: posts/, config/posts.config.ts, public/assets/images/ (썸네일 업로드 시)
+              </p>
+            </div>
+          )}
+
+          {stage === 'preview' && (
+            <button
+              onClick={handlePublish}
+              className="px-6 py-2 bg-green-600 text-white rounded cursor-pointer"
+            >
+              게시
+            </button>
+          )}
+
+          {stage === 'publishing' && (
+            <div className="flex items-center gap-2 text-gray-600">
+              <div className="w-5 h-5 border-4 border-green-400 border-t-transparent rounded-full animate-spin" />
+              <span>게시 중...</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Field({ label, children }: { label: string; children: ReactElement }) {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-700 mb-1">{label}</label>
+      {children}
+    </div>
+  )
+}
+
+export default AuthoringPage

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
+      isomorphic-dompurify:
+        specifier: ^3.12.0
+        version: 3.12.0
       lucide-react:
         specifier: ^1.14.0
         version: 1.14.0(react@19.2.6)
@@ -88,9 +91,64 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.0':
+    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -138,6 +196,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -564,6 +631,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@typescript-eslint/eslint-plugin@8.59.2':
     resolution: {integrity: sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -835,6 +905,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
@@ -892,6 +965,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -902,6 +979,10 @@ packages:
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -932,6 +1013,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -955,6 +1039,9 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dompurify@3.4.2:
+    resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
+
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
@@ -975,6 +1062,10 @@ packages:
   enhanced-resolve@5.21.2:
     resolution: {integrity: sha512-xe9vQb5kReirPUxgQrXA3ihgbCqssmTiM7cOZ+Gzu+VeGWgpV98lLZvp0dl4yriyAePcewxGUs9UpKD8PET9KQ==}
     engines: {node: '>=10.13.0'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -1276,6 +1367,10 @@ packages:
     resolution: {integrity: sha512-HVJyzUrLIL1c0QmviVh5E8VGyUS7xCFPS6yydaVd1UegW+ibV/CohqTH9MkOLDp5o+rb82DMo77PTuc9F/8GKw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
@@ -1372,6 +1467,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -1414,6 +1512,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isomorphic-dompurify@3.12.0:
+    resolution: {integrity: sha512-8n+j+6ypTHvriJwFOQ2qusQ6bzGjZVcR3jbe1pBpLcGI1dn4WIl0ctLBngqE5QttquQBAlKXwJeTMw+X7x7qKw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -1431,6 +1533,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -1563,6 +1674,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.3.6:
+    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
+    engines: {node: 20 || >=22}
+
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
@@ -1586,6 +1701,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1727,6 +1845,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1813,6 +1934,10 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -1843,6 +1968,10 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2003,6 +2132,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@4.3.0:
     resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
 
@@ -2014,9 +2146,24 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tldts-core@7.0.30:
+    resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
+
+  tldts@7.0.30:
+    resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   treeify@1.1.0:
     resolution: {integrity: sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==}
@@ -2080,6 +2227,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -2094,6 +2245,22 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -2128,6 +2295,13 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
@@ -2140,9 +2314,57 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -2205,6 +2427,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.0': {}
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -2525,6 +2749,9 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -2795,6 +3022,10 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -2856,11 +3087,23 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -2888,6 +3131,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -2910,6 +3155,10 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dompurify@3.4.2:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   dotenv@16.6.1: {}
 
   dunder-proto@1.0.1:
@@ -2928,6 +3177,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@8.0.0: {}
 
   es-abstract@1.24.2:
     dependencies:
@@ -3380,6 +3631,12 @@ snapshots:
     dependencies:
       lru-cache: 7.18.3
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   husky@9.1.7: {}
 
   ignore@5.3.2: {}
@@ -3474,6 +3731,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -3517,6 +3776,14 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isomorphic-dompurify@3.12.0:
+    dependencies:
+      dompurify: 3.4.2
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - canvas
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -3539,6 +3806,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.6
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   json-buffer@3.0.1: {}
 
@@ -3653,6 +3946,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.3.6: {}
+
   lru-cache@7.18.3: {}
 
   lucide-react@1.14.0(react@19.2.6):
@@ -3668,6 +3963,8 @@ snapshots:
   marked@4.3.0: {}
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   merge2@1.4.1: {}
 
@@ -3816,6 +4113,10 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -3908,6 +4209,8 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -3945,6 +4248,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -4166,6 +4473,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tailwindcss@4.3.0: {}
 
   tapable@2.3.3: {}
@@ -4175,9 +4484,23 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tldts-core@7.0.30: {}
+
+  tldts@7.0.30:
+    dependencies:
+      tldts-core: 7.0.30
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.30
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   treeify@1.1.0: {}
 
@@ -4260,6 +4583,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@7.25.0: {}
+
   unrs-resolver@1.11.1:
     dependencies:
       napi-postinstall: 0.3.4
@@ -4296,6 +4621,22 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -4355,6 +4696,10 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.2.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yn@3.1.1: {}
 

--- a/utils/MarkdownUtil.ts
+++ b/utils/MarkdownUtil.ts
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import DOMPurify from 'isomorphic-dompurify'
 import { marked } from 'marked'
 import path from 'path'
 
@@ -6,7 +7,8 @@ export class MarkdownUtil {
   static readonly publicPath: string = './public'
 
   static getMarkdownContent(mdFilePath: string): string {
-    return marked(this.readFileSync(mdFilePath))
+    const html = marked(this.readFileSync(mdFilePath)) as string
+    return DOMPurify.sanitize(html)
   }
 
   static readFileSync(filePath: string): string {

--- a/utils/dev/AuthoringPrompt.ts
+++ b/utils/dev/AuthoringPrompt.ts
@@ -1,0 +1,84 @@
+// SERVER-ONLY module. Never import from a client component.
+if (typeof window !== 'undefined') {
+  throw new Error('AuthoringPrompt must only be imported in server-side (Node.js) code.')
+}
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { CATEGORIES, Post } from '../../config/posts.config'
+import { GENERATED_POST_JSON_SCHEMA } from './types'
+
+export interface AuthoringPromptOptions {
+  userInstruction: string
+  today: string               // YYYY-MM-DD — server's local date
+  publishedPosts: Post[]      // from postsDatabase
+  thumbnailFileNames: string[] // files in public/assets/images/
+}
+
+/**
+ * Write the JSON Schema to a temp file and return its path.
+ * The file persists for the lifetime of the process (callers do not need to
+ * clean it up; it is tiny and in os.tmpdir()).
+ */
+let _schemaFilePath: string | null = null
+export function getSchemaFilePath(): string {
+  if (_schemaFilePath && fs.existsSync(_schemaFilePath)) return _schemaFilePath
+  _schemaFilePath = path.join(os.tmpdir(), 'codex-post-schema.json')
+  fs.writeFileSync(_schemaFilePath, JSON.stringify(GENERATED_POST_JSON_SCHEMA, null, 2), 'utf8')
+  return _schemaFilePath
+}
+
+/**
+ * Build the full prompt string to pass to codex via stdin.
+ */
+export function buildAuthoringPrompt(opts: AuthoringPromptOptions): string {
+  const { userInstruction, today, publishedPosts, thumbnailFileNames } = opts
+
+  const categoriesBlock = Object.entries(CATEGORIES)
+    .map(([key, value]) => `  - key: "${key}"  display: "${value}"`)
+    .join('\n')
+
+  const catalogBlock = publishedPosts
+    .map((p) => `  - title: "${p.title}" | category: "${p.category}" | tags: ${p.tags.join(', ')}`)
+    .join('\n')
+
+  const thumbnailsBlock = thumbnailFileNames.map((f) => `  - ${f}`).join('\n')
+
+  return `You are a senior technical writer for a Korean developer blog (code-logs).
+Your task: produce exactly ONE complete blog post in JSON that strictly conforms to the provided JSON Schema.
+
+=== CATEGORIES (use the "key" field for the "category" property) ===
+${categoriesBlock}
+
+=== PUBLISHED POST CATALOG (use for references and to avoid duplicate topics) ===
+${catalogBlock}
+
+=== EXISTING THUMBNAIL FILES (prefer reuse; list exact filename when reusing) ===
+${thumbnailsBlock}
+
+=== STYLE RULES ===
+1. Language: Korean prose (technical terms may remain in English).
+2. Format: Markdown only — NO frontmatter (no ---/--- block).
+3. Heading hierarchy: start at ## (the blog renders the title as <h1>).
+4. Code blocks: use fenced \`\`\`lang syntax compatible with Highlight.js.
+5. Emoji: allowed sparingly where natural.
+6. Length: thorough — a real blog post, not a stub.
+
+=== fileName RULES ===
+- kebab-case, ends with .md (e.g. "use-action-state.md").
+- Must NOT match any existing fileName in the catalog above.
+- Must NOT contain spaces or uppercase.
+
+=== publishedAt ===
+Use today's date: ${today}
+
+=== THUMBNAIL RULES ===
+- Prefer "reuse": pick the most thematically fitting file from the EXISTING THUMBNAIL FILES list and set mode="reuse", reuseFileName=<that filename>.
+- If absolutely nothing fits, set mode="generate" and provide a concise image-generation prompt in generatePrompt.
+
+=== USER INSTRUCTION ===
+${userInstruction}
+
+Respond with ONLY valid JSON matching the schema — no markdown fences, no prose outside the JSON.`
+}

--- a/utils/dev/AuthoringPrompt.ts
+++ b/utils/dev/AuthoringPrompt.ts
@@ -18,15 +18,13 @@ export interface AuthoringPromptOptions {
 
 /**
  * Write the JSON Schema to a temp file and return its path.
- * The file persists for the lifetime of the process (callers do not need to
- * clean it up; it is tiny and in os.tmpdir()).
+ * Rewritten on every call so HMR-updated schema content always wins over any
+ * stale file left from a prior dev-server run.
  */
-let _schemaFilePath: string | null = null
 export function getSchemaFilePath(): string {
-  if (_schemaFilePath && fs.existsSync(_schemaFilePath)) return _schemaFilePath
-  _schemaFilePath = path.join(os.tmpdir(), 'codex-post-schema.json')
-  fs.writeFileSync(_schemaFilePath, JSON.stringify(GENERATED_POST_JSON_SCHEMA, null, 2), 'utf8')
-  return _schemaFilePath
+  const schemaFilePath = path.join(os.tmpdir(), 'codex-post-schema.json')
+  fs.writeFileSync(schemaFilePath, JSON.stringify(GENERATED_POST_JSON_SCHEMA, null, 2), 'utf8')
+  return schemaFilePath
 }
 
 /**

--- a/utils/dev/CodexClient.ts
+++ b/utils/dev/CodexClient.ts
@@ -1,0 +1,103 @@
+// SERVER-ONLY module. Never import from a client component.
+if (typeof window !== 'undefined') {
+  throw new Error('CodexClient must only be imported in server-side (Node.js) code.')
+}
+
+import { spawn } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+export interface CodexRunOptions {
+  prompt: string
+  /** Path to a JSON Schema file passed via --output-schema */
+  schemaPath?: string
+  /** Timeout in milliseconds (default 300_000 = 5 min) */
+  timeoutMs?: number
+  /** Working directory for the codex process (default: process.cwd()) */
+  cwd?: string
+}
+
+/**
+ * Invoke `codex exec` non-interactively and return the last message text.
+ *
+ * Prerequisite: `codex` must be installed and on $PATH, and the user must
+ * have authenticated with `codex login`. This wrapper surfaces auth errors
+ * via the thrown Error's message.
+ */
+export async function runCodex(options: CodexRunOptions): Promise<string> {
+  const { prompt, schemaPath, timeoutMs = 300_000, cwd = process.cwd() } = options
+
+  // Write the last-message output to a temp file so we can read it reliably.
+  const tmpFile = path.join(os.tmpdir(), `codex-output-${Date.now()}.json`)
+
+  const args = [
+    'exec',
+    '--json',
+    '--skip-git-repo-check',
+    '--sandbox',
+    'workspace-write',
+    '--output-last-message',
+    tmpFile,
+    ...(schemaPath ? ['--output-schema', schemaPath] : []),
+    '-', // read prompt from stdin
+  ]
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('codex', args, {
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env },
+    })
+
+    let stderrBuf = ''
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderrBuf += chunk.toString()
+    })
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      try { fs.unlinkSync(tmpFile) } catch { /* ignore ENOENT and other errors */ }
+      reject(new Error(`codex timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        reject(new Error('codex CLI not found on $PATH. Install it and run `codex login` before using the authoring page.'))
+      } else {
+        reject(err)
+      }
+    })
+
+    child.on('close', (code) => {
+      clearTimeout(timer)
+
+      if (code !== 0) {
+        // Clean up the temp file on non-zero exit (it may not exist; ignore errors).
+        try { fs.unlinkSync(tmpFile) } catch { /* ignore ENOENT and other errors */ }
+        reject(new Error(`codex exited with code ${code}.\n\nstderr:\n${stderrBuf}`))
+        return
+      }
+
+      let output: string
+      try {
+        output = fs.readFileSync(tmpFile, 'utf8')
+      } catch {
+        reject(new Error(`codex completed but output file not found at ${tmpFile}.\n\nstderr:\n${stderrBuf}`))
+        return
+      } finally {
+        // Clean up the temp file regardless of whether read succeeded.
+        try { fs.unlinkSync(tmpFile) } catch { /* ignore ENOENT and other errors */ }
+      }
+
+      resolve(output)
+    })
+
+    // Write the prompt to stdin and close it.
+    // Suppress EPIPE / ECONNRESET if Codex exits before reading stdin.
+    child.stdin.on('error', () => {})
+    child.stdin.write(prompt, 'utf8')
+    child.stdin.end()
+  })
+}

--- a/utils/dev/CodexClient.ts
+++ b/utils/dev/CodexClient.ts
@@ -51,8 +51,14 @@ export async function runCodex(options: CodexRunOptions): Promise<string> {
     })
 
     let stderrBuf = ''
+    let stdoutBuf = ''
     child.stderr.on('data', (chunk: Buffer) => {
       stderrBuf += chunk.toString()
+    })
+    // With --json, codex emits JSONL events (including failure events) on stdout.
+    // Capture it so non-zero exits surface a useful diagnostic.
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdoutBuf += chunk.toString()
     })
 
     const timer = setTimeout(() => {
@@ -76,7 +82,8 @@ export async function runCodex(options: CodexRunOptions): Promise<string> {
       if (code !== 0) {
         // Clean up the temp file on non-zero exit (it may not exist; ignore errors).
         try { fs.unlinkSync(tmpFile) } catch { /* ignore ENOENT and other errors */ }
-        reject(new Error(`codex exited with code ${code}.\n\nstderr:\n${stderrBuf}`))
+        const tail = stdoutBuf.slice(-2000)
+        reject(new Error(`codex exited with code ${code}.\n\nstderr:\n${stderrBuf}\n\nstdout (last 2KB):\n${tail}`))
         return
       }
 

--- a/utils/dev/PostConfigWriter.ts
+++ b/utils/dev/PostConfigWriter.ts
@@ -1,0 +1,111 @@
+// SERVER-ONLY module. Never import from a client component.
+if (typeof window !== 'undefined') {
+  throw new Error('PostConfigWriter must only be imported in server-side (Node.js) code.')
+}
+
+import fs from 'fs'
+import path from 'path'
+import { CATEGORIES } from '../../config/posts.config'
+import { GeneratedPostMetadata } from './types'
+
+const CONFIG_PATH = path.join(process.cwd(), 'config', 'posts.config.ts')
+
+/** Expected suffix of posts.config.ts after the closing ] of the posts array */
+const EXPECTED_TAIL = ']\n\nexport default posts\n'
+
+/**
+ * Append a new Post entry to config/posts.config.ts.
+ *
+ * Strategy: locate the closing `]` of the `posts` array (the last `]` before
+ * `\n\nexport default posts\n`) and splice in the serialized entry.
+ *
+ * Throws if:
+ * - The file does not end with the expected pattern (file has been edited).
+ * - category is not a valid CATEGORIES key.
+ * - fileName already exists in the file (duplicate guard).
+ */
+export function appendPostConfig(metadata: GeneratedPostMetadata, thumbnailName: string): void {
+  // Sanity check: category key must exist in CATEGORIES
+  if (!(metadata.category in CATEGORIES)) {
+    throw new Error(
+      `Unknown category key: "${metadata.category}". ` +
+      `Valid keys: ${Object.keys(CATEGORIES).join(', ')}`
+    )
+  }
+
+  const raw = fs.readFileSync(CONFIG_PATH, 'utf8')
+
+  // Guard: file must end exactly as expected
+  if (!raw.endsWith(EXPECTED_TAIL)) {
+    throw new Error(
+      `posts.config.ts does not end with the expected pattern (\`${EXPECTED_TAIL.trim()}\`). ` +
+      'Refusing to mutate the file automatically. Append the entry manually.'
+    )
+  }
+
+  // Guard: fileName must not already exist
+  if (raw.includes(`fileName: '${metadata.fileName}'`) || raw.includes(`fileName: "${metadata.fileName}"`)) {
+    throw new Error(`fileName "${metadata.fileName}" already exists in posts.config.ts.`)
+  }
+
+  // Build the new entry string — mirrors the style of the last entries in the file:
+  // backtick strings for title/description/publishedAt, single-quoted for fileName/thumbnailName
+  const entry = serializeEntry(metadata, thumbnailName)
+
+  // Insert before the closing `]` (which is at index: raw.length - EXPECTED_TAIL.length).
+  // Append the comma to the prior entry's closing brace line (i.e. replace the trailing
+  // newline before `]` with `,\n`) so the separator reads `},\n  {` not `}\n,\n  {`.
+  const insertAt = raw.length - EXPECTED_TAIL.length
+  const before = raw.slice(0, insertAt) // ends with "  }\n"
+  const updated = before.replace(/\n$/, ',\n') + entry + '\n' + raw.slice(insertAt)
+
+  fs.writeFileSync(CONFIG_PATH, updated, 'utf8')
+}
+
+function serializeEntry(meta: GeneratedPostMetadata, thumbnailName: string): string {
+  const indent = '  '
+  const tagItems = meta.tags.map((t) => `\`${t}\``).join(', ')
+
+  let block = `${indent}{\n`
+  block += `${indent}  title: \`${escapeBt(meta.title)}\`,\n`
+  block += `${indent}  description: \`${escapeBt(meta.description)}\`,\n`
+  block += `${indent}  fileName: '${meta.fileName}',\n`
+  block += `${indent}  category: '${meta.category}',\n`
+  block += `${indent}  published: true,\n`
+  block += `${indent}  publishedAt: \`${meta.publishedAt}\`,\n`
+  block += `${indent}  thumbnailName: \`${escapeBt(thumbnailName)}\`,\n`
+  block += `${indent}  tags: [${tagItems}],\n`
+
+  if (meta.references && meta.references.length > 0) {
+    block += `${indent}  references: [\n`
+    for (const ref of meta.references) {
+      block += `${indent}    {\n`
+      block += `${indent}      title: \`${escapeBt(ref.title)}\`,\n`
+      block += `${indent}      url: \`${escapeBt(ref.url)}\`,\n`
+      block += `${indent}    },\n`
+    }
+    block += `${indent}  ],\n`
+  }
+
+  block += `${indent}}`
+  return block
+}
+
+/** Escape backtick characters inside a template literal string */
+function escapeBt(s: string): string {
+  return s.replace(/`/g, '\\`').replace(/\$/g, '\\$')
+}
+
+/**
+ * Get the directory name for a category key.
+ *
+ * The CATEGORIES map key IS the directory name (e.g. 'react-native' → posts/react-native/).
+ * The value is the display string ('react native'). Do not confuse them.
+ */
+export function getCategoryDir(categoryKey: keyof typeof CATEGORIES): string {
+  if (!(categoryKey in CATEGORIES)) {
+    throw new Error(`Unknown category key: "${categoryKey}"`)
+  }
+  // The key is the directory name — no transformation needed.
+  return categoryKey
+}

--- a/utils/dev/PostConfigWriter.ts
+++ b/utils/dev/PostConfigWriter.ts
@@ -64,24 +64,24 @@ export function appendPostConfig(metadata: GeneratedPostMetadata, thumbnailName:
 
 function serializeEntry(meta: GeneratedPostMetadata, thumbnailName: string): string {
   const indent = '  '
-  const tagItems = meta.tags.map((t) => `\`${t}\``).join(', ')
+  const tagItems = meta.tags.map(toTemplateLiteral).join(', ')
 
   let block = `${indent}{\n`
-  block += `${indent}  title: \`${escapeBt(meta.title)}\`,\n`
-  block += `${indent}  description: \`${escapeBt(meta.description)}\`,\n`
+  block += `${indent}  title: ${toTemplateLiteral(meta.title)},\n`
+  block += `${indent}  description: ${toTemplateLiteral(meta.description)},\n`
   block += `${indent}  fileName: '${meta.fileName}',\n`
   block += `${indent}  category: '${meta.category}',\n`
   block += `${indent}  published: true,\n`
-  block += `${indent}  publishedAt: \`${meta.publishedAt}\`,\n`
-  block += `${indent}  thumbnailName: \`${escapeBt(thumbnailName)}\`,\n`
+  block += `${indent}  publishedAt: ${toTemplateLiteral(meta.publishedAt)},\n`
+  block += `${indent}  thumbnailName: ${toTemplateLiteral(thumbnailName)},\n`
   block += `${indent}  tags: [${tagItems}],\n`
 
   if (meta.references && meta.references.length > 0) {
     block += `${indent}  references: [\n`
     for (const ref of meta.references) {
       block += `${indent}    {\n`
-      block += `${indent}      title: \`${escapeBt(ref.title)}\`,\n`
-      block += `${indent}      url: \`${escapeBt(ref.url)}\`,\n`
+      block += `${indent}      title: ${toTemplateLiteral(ref.title)},\n`
+      block += `${indent}      url: ${toTemplateLiteral(ref.url)},\n`
       block += `${indent}    },\n`
     }
     block += `${indent}  ],\n`
@@ -91,9 +91,9 @@ function serializeEntry(meta: GeneratedPostMetadata, thumbnailName: string): str
   return block
 }
 
-/** Escape backtick characters inside a template literal string */
-function escapeBt(s: string): string {
-  return s.replace(/`/g, '\\`').replace(/\$/g, '\\$')
+/** Serialize a string as a TypeScript template literal. */
+function toTemplateLiteral(s: string): string {
+  return `\`${s.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$/g, '\\$')}\``
 }
 
 /**

--- a/utils/dev/ThumbnailResolver.ts
+++ b/utils/dev/ThumbnailResolver.ts
@@ -1,0 +1,69 @@
+// SERVER-ONLY module. Never import from a client component.
+if (typeof window !== 'undefined') {
+  throw new Error('ThumbnailResolver must only be imported in server-side (Node.js) code.')
+}
+
+import fs from 'fs'
+import path from 'path'
+import { GeneratedPostThumbnail } from './types'
+
+const IMAGES_DIR = path.join(process.cwd(), 'public', 'assets', 'images')
+
+/**
+ * Resolve the thumbnail for a post.
+ *
+ * - mode: 'reuse' — verifies reuseFileName exists in public/assets/images/.
+ *   Returns the filename to store in `thumbnailName`.
+ *
+ * - mode: 'generate' — writes uploadedImageBuffer to public/assets/images/<targetFileName>.
+ *   Returns targetFileName to store in `thumbnailName`.
+ *   uploadedImageBuffer and targetFileName are required when mode === 'generate'.
+ *
+ * Throws a descriptive Error if preconditions are not met.
+ */
+export function resolveThumbnail(
+  thumbnail: GeneratedPostThumbnail,
+  opts?: {
+    /** Required when thumbnail.mode === 'generate' */
+    uploadedImageBuffer?: Buffer
+    /** Required when thumbnail.mode === 'generate': desired filename (kebab slug + extension) */
+    targetFileName?: string
+  }
+): string {
+  if (thumbnail.mode === 'reuse') {
+    const fileName = thumbnail.reuseFileName
+    if (!fileName) {
+      throw new Error('thumbnail.mode is "reuse" but reuseFileName is missing.')
+    }
+    const fullPath = path.join(IMAGES_DIR, fileName)
+    // Containment check: ensure the resolved path stays inside IMAGES_DIR
+    if (!path.resolve(fullPath).startsWith(path.resolve(IMAGES_DIR) + path.sep)) {
+      throw new Error(`Invalid reuseFileName: "${fileName}" resolves outside the images directory.`)
+    }
+    if (!fs.existsSync(fullPath)) {
+      throw new Error(`Thumbnail file not found: public/assets/images/${fileName}`)
+    }
+    return fileName
+  }
+
+  // mode === 'generate'
+  const { uploadedImageBuffer, targetFileName } = opts ?? {}
+  if (!uploadedImageBuffer || !targetFileName) {
+    throw new Error(
+      'thumbnail.mode is "generate" but no image was uploaded. ' +
+      'Please upload a thumbnail image in the authoring UI.'
+    )
+  }
+  const dest = path.join(IMAGES_DIR, targetFileName)
+  fs.writeFileSync(dest, uploadedImageBuffer)
+  return targetFileName
+}
+
+/** List all filenames in public/assets/images/ */
+export function listThumbnailFiles(): string[] {
+  try {
+    return fs.readdirSync(IMAGES_DIR)
+  } catch {
+    return []
+  }
+}

--- a/utils/dev/_empty-module.js
+++ b/utils/dev/_empty-module.js
@@ -1,0 +1,8 @@
+// This module is substituted for all *.dev.tsx / *.dev.ts files during
+// production builds (see next.config.js webpack NormalModuleReplacementPlugin).
+// It exports a minimal Next.js page that returns notFound so that even if
+// Next.js somehow resolves the route, no HTML is emitted.
+module.exports = {
+  default: function EmptyDevPage() { return null },
+  getStaticProps: async function() { return { notFound: true } },
+}

--- a/utils/dev/types.ts
+++ b/utils/dev/types.ts
@@ -28,7 +28,16 @@ export interface GeneratedPost {
   thumbnail: GeneratedPostThumbnail
 }
 
-/** JSON Schema for GeneratedPost — used with codex --output-schema */
+/**
+ * JSON Schema for GeneratedPost — used with codex --output-schema.
+ *
+ * OpenAI structured outputs (which Codex uses) require `additionalProperties: false`
+ * AND every property in `properties` to be listed in `required`. To express
+ * "optional" fields, we declare them as nullable via `type: ['X', 'null']`.
+ *
+ * Node-side validation in generate-post.dev.ts treats null/missing equivalently
+ * for these fields and the TypeScript interface marks them optional.
+ */
 export const GENERATED_POST_JSON_SCHEMA = {
   type: 'object',
   required: ['metadata', 'markdown', 'thumbnail'],
@@ -36,7 +45,7 @@ export const GENERATED_POST_JSON_SCHEMA = {
   properties: {
     metadata: {
       type: 'object',
-      required: ['title', 'description', 'category', 'fileName', 'publishedAt', 'tags'],
+      required: ['title', 'description', 'category', 'fileName', 'publishedAt', 'tags', 'references'],
       additionalProperties: false,
       properties: {
         title: { type: 'string', minLength: 1 },
@@ -46,7 +55,7 @@ export const GENERATED_POST_JSON_SCHEMA = {
         publishedAt: { type: 'string', pattern: '^\\d{4}-\\d{2}-\\d{2}$' },
         tags: { type: 'array', items: { type: 'string' }, minItems: 1 },
         references: {
-          type: 'array',
+          type: ['array', 'null'],
           items: {
             type: 'object',
             required: ['title', 'url'],
@@ -62,12 +71,12 @@ export const GENERATED_POST_JSON_SCHEMA = {
     markdown: { type: 'string', minLength: 1 },
     thumbnail: {
       type: 'object',
-      required: ['mode'],
+      required: ['mode', 'reuseFileName', 'generatePrompt'],
       additionalProperties: false,
       properties: {
         mode: { type: 'string', enum: ['reuse', 'generate'] },
-        reuseFileName: { type: 'string', pattern: '^[\\w.\\-]+$' },
-        generatePrompt: { type: 'string' },
+        reuseFileName: { type: ['string', 'null'], pattern: '^[\\w.\\-]+$' },
+        generatePrompt: { type: ['string', 'null'] },
       },
     },
   },

--- a/utils/dev/types.ts
+++ b/utils/dev/types.ts
@@ -1,0 +1,74 @@
+import { CATEGORIES } from '../../config/posts.config'
+
+export interface GeneratedPostMetadata {
+  title: string
+  description: string
+  /** Must be one of the keys in the CATEGORIES map (e.g. 'react', 'react-native') */
+  category: keyof typeof CATEGORIES
+  /** kebab-case filename ending with .md (e.g. 'use-action-state.md') */
+  fileName: string
+  /** ISO date string YYYY-MM-DD */
+  publishedAt: string
+  tags: string[]
+  references?: { title: string; url: string }[]
+}
+
+export interface GeneratedPostThumbnail {
+  mode: 'reuse' | 'generate'
+  /** When mode === 'reuse': the existing filename in public/assets/images/ */
+  reuseFileName?: string
+  /** When mode === 'generate': a descriptive prompt for creating a thumbnail image */
+  generatePrompt?: string
+}
+
+export interface GeneratedPost {
+  metadata: GeneratedPostMetadata
+  /** Full markdown body — no frontmatter; headings start at ## */
+  markdown: string
+  thumbnail: GeneratedPostThumbnail
+}
+
+/** JSON Schema for GeneratedPost — used with codex --output-schema */
+export const GENERATED_POST_JSON_SCHEMA = {
+  type: 'object',
+  required: ['metadata', 'markdown', 'thumbnail'],
+  additionalProperties: false,
+  properties: {
+    metadata: {
+      type: 'object',
+      required: ['title', 'description', 'category', 'fileName', 'publishedAt', 'tags'],
+      additionalProperties: false,
+      properties: {
+        title: { type: 'string', minLength: 1 },
+        description: { type: 'string', minLength: 1 },
+        category: { type: 'string', enum: Object.keys(CATEGORIES) },
+        fileName: { type: 'string', pattern: '^[a-z0-9-]+\\.md$' },
+        publishedAt: { type: 'string', pattern: '^\\d{4}-\\d{2}-\\d{2}$' },
+        tags: { type: 'array', items: { type: 'string' }, minItems: 1 },
+        references: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['title', 'url'],
+            additionalProperties: false,
+            properties: {
+              title: { type: 'string' },
+              url: { type: 'string' },
+            },
+          },
+        },
+      },
+    },
+    markdown: { type: 'string', minLength: 1 },
+    thumbnail: {
+      type: 'object',
+      required: ['mode'],
+      additionalProperties: false,
+      properties: {
+        mode: { type: 'string', enum: ['reuse', 'generate'] },
+        reuseFileName: { type: 'string', pattern: '^[\\w.\\-]+$' },
+        generatePrompt: { type: 'string' },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## 요약
dev 전용 글 작성 페이지에서 자유 형식 지시문 입력 → 로컬 `codex` CLI 호출 → 본문·메타데이터·references·thumbnail 결정을 한 번에 생성. 미리보기 후 "게시" 시 파일 시스템에 반영하며, production static export(`pnpm run docs`)에는 포함되지 않습니다.

## 변경 사항
- `.dev.tsx`/`.dev.ts` 접미사 + `pageExtensions` 필터 + webpack `NormalModuleReplacementPlugin`으로 production 빌드 격리
- `pnpm run docs` 스크립트에 `rm -rf ./docs/dev` 추가 (Next.js가 export 시 남기는 빈 디렉토리 정리)
- `utils/dev/` 서버 전용 모듈 신설: `CodexClient`, `AuthoringPrompt`, `PostConfigWriter`, `ThumbnailResolver`
- `pages/dev/authoring.dev.tsx`: 입력 → 생성 → 미리보기 → 게시 흐름 UI
- `pages/api/dev/generate-post.dev.ts`, `publish-post.dev.ts`: 생성·게시 API 라우트
- `posts.config.ts` append: 기존 스타일(백틱 문자열, 콤마 위치) 보존
- `ThumbnailResolver`에 path-traversal containment + JSON Schema \`pattern\` 방어
- v1 thumbnail 정책: \`reuse\` 자동, \`generate\`는 수동 업로드 (자동 이미지 생성은 별도 이슈)
- `CLAUDE.md`에 라우팅 포인터, `.claude/docs/dev-authoring-pipeline.md`에 상세 gotcha 문서화

## 관련 이슈
Closes #108

## 테스트 체크리스트
- [ ] \`pnpm dev\` → \`/dev/authoring\` 접속 시 입력 폼 렌더링 확인
- [ ] 추가 지시문 입력 후 "생성" → \`codex\` CLI 호출 → 마크다운·메타·thumbnail 결정 반환
- [ ] 미리보기에서 메타 편집, \`marked\` 렌더링, \`hljs\` 코드 하이라이트 정상
- [ ] thumbnail \`reuse\` 모드: 기존 이미지 표시 / \`generate\` 모드: 파일 업로드 UI 노출
- [ ] "게시" → \`posts/<category>/<fileName>.md\`, \`config/posts.config.ts\` append, 필요 시 \`public/assets/images/<thumbnail>\` 기록
- [ ] 생성된 포스트가 \`/<normalized-title>\`로 정상 렌더링
- [ ] \`pnpm run docs\` 후 \`docs/dev/\`, \`docs/api/\` 디렉토리 없음 + 빌드 에러 없음
- [ ] \`posts.config.ts\` 패턴 검증 실패 시(파일 tail 변경) 명확한 에러 발생
- [ ] 파일명 중복 시 4xx 에러 + 디스크 미변경