### PR TITLE
feat(dev): Codex 프롬프트 분리 입력 UI 및 페이지 디자인 개편

### DIFF
--- a/.claude/docs/dev-authoring-pipeline.md
+++ b/.claude/docs/dev-authoring-pipeline.md
@@ -40,11 +40,11 @@ The dev authoring pipeline is a local-only UI (`/dev/authoring`) that calls the 
 - **Root cause**: `CodexClient` calls `child_process.spawn('codex', ...)`. `codex` must be installed globally and on `$PATH` as a system binary. It is deliberately absent from `package.json`.
 - **Rule**: NEVER add `codex` as a project npm dependency. Before using the authoring page, run `codex login` once. Confirm it is reachable with `which codex`.
 
-### `generate-post` accepts a full prompt string, not a `userInstruction` field
+### `generate-post` request body splits topic from additional instruction
 
-- **Symptom**: `POST /api/dev/generate-post` returns 400 with "prompt must be a non-empty string (min 50 chars)".
-- **Root cause**: the request body schema changed from `{ userInstruction: string }` to `{ prompt: string }`. Callers that still send `userInstruction` receive a 400 because the field is no longer read.
-- **Rule**: ALWAYS send the full assembled prompt in the `prompt` field. The server does NOT reassemble the prompt — it passes the client-supplied string directly to Codex. The client is responsible for fetching and editing the default prompt via `GET /api/dev/default-prompt` first.
+- **Symptom**: `POST /api/dev/generate-post` returns 400 with "topic is required".
+- **Root cause**: the request body is `{ topic: string, additionalInstruction?: string }`. The server reassembles the full prompt with `buildAuthoringPrompt({ today, topic, additionalInstruction })` — the client never sends a full prompt string.
+- **Rule**: NEVER let the client send the full prompt. The Core template (style rules, workspace layout, schema constraints) is server-owned and must not be user-editable. Only `topic` (required) and `additionalInstruction` (optional) come from the client.
 
 ### Default prompt MUST reference workspace paths, NEVER embed data dumps
 
@@ -82,14 +82,14 @@ The dev authoring pipeline is a local-only UI (`/dev/authoring`) that calls the 
 
 NEVER import anything from `utils/dev/` in a client component or non-dev page. These modules use `child_process` and other Node-only APIs that will break the client bundle.
 
-### Prompt assembly and editing flow
+### Prompt assembly flow
 
-The prompt pipeline has two stages:
+The Core template is server-owned. Only TOPIC and ADDITIONAL INSTRUCTIONS slots are user-editable.
 
-1. **Default prompt assembly** (`GET /api/dev/default-prompt`): `buildAuthoringPrompt()` in `utils/dev/AuthoringPrompt.ts` returns a path-referenced template plus today's date. It does NOT read postsDatabase or list thumbnails — Codex resolves those at run time by reading `config/posts.config.ts` and `public/assets/images/` directly. The response sets `Cache-Control: no-store` and is displayed in the authoring textarea.
-2. **Generation** (`POST /api/dev/generate-post`): the client sends the edited textarea content as `{ prompt: string }`. The server passes it unchanged to Codex. `buildAuthoringPrompt()` is NOT called at generation time.
+1. **Core preview** (`GET /api/dev/default-prompt`): returns `buildAuthoringPrompt({ today })` with placeholder strings in the TOPIC and ADDITIONAL INSTRUCTIONS slots. Used for the read-only reference panel in the UI. `Cache-Control: no-store`.
+2. **Generation** (`POST /api/dev/generate-post`): client sends `{ topic, additionalInstruction? }`. Server reassembles via `buildAuthoringPrompt({ today, topic, additionalInstruction })` and passes the result to Codex.
 
-The `userInstruction` parameter of `buildAuthoringPrompt` is optional; when omitted, the `=== USER INSTRUCTION ===` block contains a placeholder string. The client is responsible for the user filling in that section before submitting.
+The `topic` and `additionalInstruction` parameters are both optional in the function signature so the GET preview path can render placeholders; the POST handler enforces `topic` non-empty at the API layer.
 
 ### Codex CLI invocation
 

--- a/.claude/docs/dev-authoring-pipeline.md
+++ b/.claude/docs/dev-authoring-pipeline.md
@@ -40,6 +40,18 @@ The dev authoring pipeline is a local-only UI (`/dev/authoring`) that calls the 
 - **Root cause**: `CodexClient` calls `child_process.spawn('codex', ...)`. `codex` must be installed globally and on `$PATH` as a system binary. It is deliberately absent from `package.json`.
 - **Rule**: NEVER add `codex` as a project npm dependency. Before using the authoring page, run `codex login` once. Confirm it is reachable with `which codex`.
 
+### `generate-post` accepts a full prompt string, not a `userInstruction` field
+
+- **Symptom**: `POST /api/dev/generate-post` returns 400 with "prompt must be a non-empty string (min 50 chars)".
+- **Root cause**: the request body schema changed from `{ userInstruction: string }` to `{ prompt: string }`. Callers that still send `userInstruction` receive a 400 because the field is no longer read.
+- **Rule**: ALWAYS send the full assembled prompt in the `prompt` field. The server does NOT reassemble the prompt — it passes the client-supplied string directly to Codex. The client is responsible for fetching and editing the default prompt via `GET /api/dev/default-prompt` first.
+
+### `GET /api/dev/default-prompt` must return a fresh prompt on every call
+
+- **Symptom**: category list, post catalog, or thumbnail list in the prompt textarea is stale after new posts are published or thumbnails added.
+- **Root cause**: the default prompt is assembled at request time from live data (postsDatabase, listThumbnailFiles, today's date). However, the browser will NOT refetch the prompt automatically while the authoring page stays open.
+- **Rule**: the endpoint sets `Cache-Control: no-store` to prevent browser caching. Users who need a fresh catalog MUST click "기본값으로 되돌리기" to trigger a re-fetch, which overwrites the textarea. The `today` timestamp embedded in the prompt reflects the server's clock at the time of the last fetch — edits that span midnight will contain a stale date.
+
 ### Codex output schema — Node-side validation is defense-in-depth, not optional
 
 - **Symptom**: downstream code receives a partial or malformed post draft and silently produces a broken `posts.config.ts` entry.
@@ -69,6 +81,15 @@ The dev authoring pipeline is a local-only UI (`/dev/authoring`) that calls the 
 | Server-only Node modules (dev) | `utils/dev/` |
 
 NEVER import anything from `utils/dev/` in a client component or non-dev page. These modules use `child_process` and other Node-only APIs that will break the client bundle.
+
+### Prompt assembly and editing flow
+
+The prompt pipeline has two stages:
+
+1. **Default prompt assembly** (`GET /api/dev/default-prompt`): `buildAuthoringPrompt()` in `utils/dev/AuthoringPrompt.ts` assembles the full prompt from live data (CATEGORIES map, postsDatabase, listThumbnailFiles, today's date). The result is returned as `{ prompt: string }` and displayed in the authoring textarea.
+2. **Generation** (`POST /api/dev/generate-post`): the client sends the edited textarea content as `{ prompt: string }`. The server passes it unchanged to Codex. `buildAuthoringPrompt()` is NOT called at generation time.
+
+The `userInstruction` parameter of `buildAuthoringPrompt` is optional; when omitted, the `=== USER INSTRUCTION ===` block contains a placeholder string. The client is responsible for the user filling in that section before submitting.
 
 ### Codex CLI invocation
 

--- a/.claude/docs/dev-authoring-pipeline.md
+++ b/.claude/docs/dev-authoring-pipeline.md
@@ -46,11 +46,11 @@ The dev authoring pipeline is a local-only UI (`/dev/authoring`) that calls the 
 - **Root cause**: the request body schema changed from `{ userInstruction: string }` to `{ prompt: string }`. Callers that still send `userInstruction` receive a 400 because the field is no longer read.
 - **Rule**: ALWAYS send the full assembled prompt in the `prompt` field. The server does NOT reassemble the prompt — it passes the client-supplied string directly to Codex. The client is responsible for fetching and editing the default prompt via `GET /api/dev/default-prompt` first.
 
-### `GET /api/dev/default-prompt` must return a fresh prompt on every call
+### Default prompt MUST reference workspace paths, NEVER embed data dumps
 
-- **Symptom**: category list, post catalog, or thumbnail list in the prompt textarea is stale after new posts are published or thumbnails added.
-- **Root cause**: the default prompt is assembled at request time from live data (postsDatabase, listThumbnailFiles, today's date). However, the browser will NOT refetch the prompt automatically while the authoring page stays open.
-- **Rule**: the endpoint sets `Cache-Control: no-store` to prevent browser caching. Users who need a fresh catalog MUST click "기본값으로 되돌리기" to trigger a re-fetch, which overwrites the textarea. The `today` timestamp embedded in the prompt reflects the server's clock at the time of the last fetch — edits that span midnight will contain a stale date.
+- **Symptom**: prompt length balloons as more posts and thumbnails are added; every new asset requires reassembling and re-sending the prompt to keep Codex current.
+- **Root cause**: embedding the full CATEGORIES map, every published post's metadata, and every thumbnail filename inline makes the prompt a snapshot that goes stale the moment any of those change.
+- **Rule**: `buildAuthoringPrompt()` MUST reference paths (`config/posts.config.ts`, `public/assets/images/`, `posts/<category-key>/`) and tell Codex to read them itself. Codex runs with `--sandbox workspace-write` and has read access to the project root, so it can resolve live state on every run. NEVER reintroduce inline catalog/thumbnail dumps in the default prompt.
 
 ### Codex output schema — Node-side validation is defense-in-depth, not optional
 
@@ -86,7 +86,7 @@ NEVER import anything from `utils/dev/` in a client component or non-dev page. T
 
 The prompt pipeline has two stages:
 
-1. **Default prompt assembly** (`GET /api/dev/default-prompt`): `buildAuthoringPrompt()` in `utils/dev/AuthoringPrompt.ts` assembles the full prompt from live data (CATEGORIES map, postsDatabase, listThumbnailFiles, today's date). The result is returned as `{ prompt: string }` and displayed in the authoring textarea.
+1. **Default prompt assembly** (`GET /api/dev/default-prompt`): `buildAuthoringPrompt()` in `utils/dev/AuthoringPrompt.ts` returns a path-referenced template plus today's date. It does NOT read postsDatabase or list thumbnails — Codex resolves those at run time by reading `config/posts.config.ts` and `public/assets/images/` directly. The response sets `Cache-Control: no-store` and is displayed in the authoring textarea.
 2. **Generation** (`POST /api/dev/generate-post`): the client sends the edited textarea content as `{ prompt: string }`. The server passes it unchanged to Codex. `buildAuthoringPrompt()` is NOT called at generation time.
 
 The `userInstruction` parameter of `buildAuthoringPrompt` is optional; when omitted, the `=== USER INSTRUCTION ===` block contains a placeholder string. The client is responsible for the user filling in that section before submitting.

--- a/.claude/docs/styling-gotchas.md
+++ b/.claude/docs/styling-gotchas.md
@@ -44,6 +44,12 @@ The project styles itself with Tailwind CSS v4 in CSS-first mode (no `tailwind.c
 - **Why:** `styles/highlight.css` is imported in `pages/_app.tsx` AFTER `globals.css` and is plain CSS (not a Tailwind layer). It owns `.hljs`, `.hljs-*`, and the `pre code` reset, and it is loaded last so it overrides preflight on code blocks.
 - **Rule:** Add or change syntax-highlight colors in `highlight.css` only. Add or change layout/typography for code blocks (e.g., border-radius on `<pre>`) also in `highlight.css`. NEVER move hljs rules into `globals.css` — the import order matters.
 
+### Bare element selectors in `globals.css` capture nested semantic tags
+
+- **Symptom:** A page-level `<header>` / `<main>` / `<aside>` / `<footer>` inside a page component starts behaving as if it were the top-level layout slot — e.g. a page's `<header>` becomes `position: sticky` and overlaps with the site header on scroll.
+- **Why:** `@layer base` in `globals.css` defines `header`, `main`, `aside`, `footer` as bare element selectors to slot the top-level layout into the `#__next` CSS grid. These selectors match **every** descendant of those tags, not just the direct children of `#__next`. So nesting another `<header>` inside `<main>` inherits `grid-area: header; position: sticky; height: var(--header-height); z-index: 1` — which collides with the real header.
+- **Rule:** Inside page components and shared components rendered under `<main>`, use `<div>` (or `<section>` / `<article>` for semantics) for page-section headers and footers. NEVER use a second `<header>` / `<main>` / `<aside>` / `<footer>` element inside `<main>`. If you genuinely need the semantic element, scope a new rule that resets the layout properties for that case.
+
 ### Token names must follow Tailwind v4's `--<namespace>-<name>` convention
 
 - **Symptom:** A custom token defined in `@theme` doesn't generate the expected utility.

--- a/pages/api/dev/default-prompt.dev.ts
+++ b/pages/api/dev/default-prompt.dev.ts
@@ -1,7 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import postsDatabase from '../../../database/post-database'
 import { buildAuthoringPrompt } from '../../../utils/dev/AuthoringPrompt'
-import { listThumbnailFiles } from '../../../utils/dev/ThumbnailResolver'
 
 if (process.env.NODE_ENV === 'production') {
   console.warn('default-prompt.dev.ts loaded in production — this should not happen')
@@ -23,10 +21,7 @@ export default function handler(
   }
 
   const today = new Date().toLocaleDateString('sv-SE')
-  const publishedPosts = postsDatabase.find()
-  const thumbnailFileNames = listThumbnailFiles()
-
-  const prompt = buildAuthoringPrompt({ today, publishedPosts, thumbnailFileNames })
+  const prompt = buildAuthoringPrompt({ today })
 
   res.setHeader('Cache-Control', 'no-store')
   return res.status(200).json({ prompt })

--- a/pages/api/dev/default-prompt.dev.ts
+++ b/pages/api/dev/default-prompt.dev.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import postsDatabase from '../../../database/post-database'
+import { buildAuthoringPrompt } from '../../../utils/dev/AuthoringPrompt'
+import { listThumbnailFiles } from '../../../utils/dev/ThumbnailResolver'
+
+if (process.env.NODE_ENV === 'production') {
+  console.warn('default-prompt.dev.ts loaded in production — this should not happen')
+}
+
+type SuccessResponse = { prompt: string }
+type ErrorResponse = { error: string }
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<SuccessResponse | ErrorResponse>
+) {
+  if (process.env.NODE_ENV === 'production') {
+    return res.status(404).end()
+  }
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const today = new Date().toLocaleDateString('sv-SE')
+  const publishedPosts = postsDatabase.find()
+  const thumbnailFileNames = listThumbnailFiles()
+
+  const prompt = buildAuthoringPrompt({ today, publishedPosts, thumbnailFileNames })
+
+  res.setHeader('Cache-Control', 'no-store')
+  return res.status(200).json({ prompt })
+}

--- a/pages/api/dev/generate-post.dev.ts
+++ b/pages/api/dev/generate-post.dev.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { getSchemaFilePath } from '../../../utils/dev/AuthoringPrompt'
+import { buildAuthoringPrompt, getSchemaFilePath } from '../../../utils/dev/AuthoringPrompt'
 import { runCodex } from '../../../utils/dev/CodexClient'
 import { CATEGORIES } from '../../../config/posts.config'
 import { GeneratedPost } from '../../../utils/dev/types'
@@ -25,12 +25,20 @@ export default async function handler(
     return res.status(405).json({ error: 'Method not allowed' })
   }
 
-  const { prompt: rawPrompt } = req.body as { prompt?: string }
-  if (!rawPrompt || typeof rawPrompt !== 'string' || rawPrompt.trim().length < 50) {
-    return res.status(400).json({ error: 'prompt must be a non-empty string (min 50 chars)' })
+  const { topic, additionalInstruction } = req.body as {
+    topic?: string
+    additionalInstruction?: string
+  }
+  if (!topic || typeof topic !== 'string' || !topic.trim()) {
+    return res.status(400).json({ error: 'topic is required' })
   }
 
-  const prompt = rawPrompt.trim()
+  const today = new Date().toLocaleDateString('sv-SE')
+  const prompt = buildAuthoringPrompt({
+    today,
+    topic: topic.trim(),
+    additionalInstruction: typeof additionalInstruction === 'string' ? additionalInstruction.trim() : undefined,
+  })
   const schemaPath = getSchemaFilePath()
 
   let rawOutput: string

--- a/pages/api/dev/generate-post.dev.ts
+++ b/pages/api/dev/generate-post.dev.ts
@@ -1,8 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import postsDatabase from '../../../database/post-database'
-import { buildAuthoringPrompt, getSchemaFilePath } from '../../../utils/dev/AuthoringPrompt'
+import { getSchemaFilePath } from '../../../utils/dev/AuthoringPrompt'
 import { runCodex } from '../../../utils/dev/CodexClient'
-import { listThumbnailFiles } from '../../../utils/dev/ThumbnailResolver'
 import { CATEGORIES } from '../../../config/posts.config'
 import { GeneratedPost } from '../../../utils/dev/types'
 
@@ -27,24 +25,13 @@ export default async function handler(
     return res.status(405).json({ error: 'Method not allowed' })
   }
 
-  const { userInstruction } = req.body as { userInstruction?: string }
-  if (!userInstruction || typeof userInstruction !== 'string' || !userInstruction.trim()) {
-    return res.status(400).json({ error: 'userInstruction is required' })
+  const { prompt: rawPrompt } = req.body as { prompt?: string }
+  if (!rawPrompt || typeof rawPrompt !== 'string' || rawPrompt.trim().length < 50) {
+    return res.status(400).json({ error: 'prompt must be a non-empty string (min 50 chars)' })
   }
 
-  // Compute today in local time (YYYY-MM-DD)
-  const today = new Date().toLocaleDateString('sv-SE') // 'sv-SE' gives YYYY-MM-DD in local TZ
-
-  const publishedPosts = postsDatabase.find()
-  const thumbnailFileNames = listThumbnailFiles()
+  const prompt = rawPrompt.trim()
   const schemaPath = getSchemaFilePath()
-
-  const prompt = buildAuthoringPrompt({
-    userInstruction: userInstruction.trim(),
-    today,
-    publishedPosts,
-    thumbnailFileNames,
-  })
 
   let rawOutput: string
   try {

--- a/pages/dev/authoring.dev.tsx
+++ b/pages/dev/authoring.dev.tsx
@@ -236,7 +236,7 @@ const AuthoringPage: NextPage = (): ReactElement => {
   return (
     <div className="space-y-8 pb-12">
         {/* Header */}
-        <header className="space-y-3">
+        <div className="space-y-3">
           <div className="flex items-center gap-3">
             <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold tracking-wide bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
               <span className="w-1.5 h-1.5 rounded-full bg-amber-500" />
@@ -246,7 +246,7 @@ const AuthoringPage: NextPage = (): ReactElement => {
           </div>
           <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-50">Codex 글 작성</h1>
           <Stepper stage={stage} />
-        </header>
+        </div>
 
         {/* Section A — Input */}
         {(stage === 'input' || stage === 'generating') && (

--- a/pages/dev/authoring.dev.tsx
+++ b/pages/dev/authoring.dev.tsx
@@ -15,8 +15,11 @@ export const getStaticProps: GetStaticProps = async () => {
 type Stage = 'input' | 'generating' | 'preview' | 'publishing' | 'done'
 
 const AuthoringPage: NextPage = (): ReactElement => {
-  // ── Input ──────────────────────────────────────────────────────────────
-  const [instruction, setInstruction] = useState('')
+  // ── Prompt editor ─────────────────────────────────────────────────────
+  const [prompt, setPrompt] = useState('')
+  const [promptDirty, setPromptDirty] = useState(false)
+  const [promptLoading, setPromptLoading] = useState(true)
+  const [promptLoadError, setPromptLoadError] = useState('')
 
   // ── Generation state ───────────────────────────────────────────────────
   const [stage, setStage] = useState<Stage>('input')
@@ -67,6 +70,27 @@ const AuthoringPage: NextPage = (): ReactElement => {
   }
   useEffect(() => () => stopTimer(), [])
 
+  // ── Fetch default prompt on mount ──────────────────────────────────────
+  async function fetchDefaultPrompt() {
+    setPromptLoading(true)
+    setPromptLoadError('')
+    try {
+      const res = await fetch('/api/dev/default-prompt')
+      const data = await res.json()
+      if (!res.ok) {
+        setPromptLoadError(data.error ?? '기본 프롬프트를 불러오지 못했습니다.')
+        return
+      }
+      setPrompt(data.prompt as string)
+      setPromptDirty(false)
+    } catch (err) {
+      setPromptLoadError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setPromptLoading(false)
+    }
+  }
+  useEffect(() => { fetchDefaultPrompt() }, [])
+
   // ── Sync markdown preview ──────────────────────────────────────────────
   useEffect(() => {
     if (!markdown) { setRenderedHtml(''); return }
@@ -98,7 +122,7 @@ const AuthoringPage: NextPage = (): ReactElement => {
 
   // ── Generate handler ───────────────────────────────────────────────────
   async function handleGenerate() {
-    if (!instruction.trim()) return
+    if (prompt.trim().length < 50) return
     setGenerateError('')
     setPublishError('')
     setPublishedUrl('')
@@ -109,7 +133,7 @@ const AuthoringPage: NextPage = (): ReactElement => {
       const res = await fetch('/api/dev/generate-post', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userInstruction: instruction }),
+        body: JSON.stringify({ prompt }),
       })
       const data = await res.json()
       if (!res.ok) {
@@ -222,16 +246,46 @@ const AuthoringPage: NextPage = (): ReactElement => {
       {/* Section A — Input */}
       {(stage === 'input' || stage === 'generating') && (
         <div className="space-y-4">
-          <label className="block font-semibold" htmlFor="instruction">
-            작성 지시
-          </label>
+          <div className="flex items-center justify-between">
+            <label className="block font-semibold" htmlFor="prompt">
+              Codex 프롬프트
+            </label>
+            <div className="flex items-center gap-3">
+              <span className="text-xs text-gray-400">{prompt.length}자</span>
+              <button
+                type="button"
+                onClick={() => {
+                  if (promptDirty) {
+                    if (!window.confirm('편집 내용을 버리고 기본값으로 되돌릴까요?')) return
+                  }
+                  fetchDefaultPrompt()
+                }}
+                disabled={stage === 'generating' || promptLoading}
+                className="text-xs text-blue-500 underline cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                기본값으로 되돌리기
+              </button>
+            </div>
+          </div>
+          {promptLoadError && (
+            <div className="flex items-center gap-3 bg-red-50 text-red-700 p-3 rounded text-sm">
+              <span>{promptLoadError}</span>
+              <button
+                type="button"
+                onClick={fetchDefaultPrompt}
+                className="underline cursor-pointer shrink-0"
+              >
+                다시 시도
+              </button>
+            </div>
+          )}
           <textarea
-            id="instruction"
-            className="w-full border rounded p-3 font-mono text-sm h-36 resize-y"
-            placeholder="예: React 19의 useActionState 사용법 정리"
-            value={instruction}
-            onChange={(e) => setInstruction(e.target.value)}
-            disabled={stage === 'generating'}
+            id="prompt"
+            className="w-full border rounded p-3 font-mono text-sm h-[60vh] resize-y"
+            placeholder={promptLoading ? '기본 프롬프트를 불러오는 중...' : '프롬프트를 입력하세요 (최소 50자)'}
+            value={prompt}
+            onChange={(e) => { setPrompt(e.target.value); setPromptDirty(true) }}
+            disabled={stage === 'generating' || promptLoading}
           />
           {generateError && (
             <pre className="bg-red-50 text-red-700 p-3 rounded text-sm whitespace-pre-wrap overflow-auto">
@@ -240,7 +294,7 @@ const AuthoringPage: NextPage = (): ReactElement => {
           )}
           <button
             onClick={handleGenerate}
-            disabled={stage === 'generating' || !instruction.trim()}
+            disabled={stage === 'generating' || promptLoading || prompt.trim().length < 50}
             className="px-6 py-2 bg-blue-600 text-white rounded disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
           >
             {stage === 'generating' ? '생성 중...' : '생성'}

--- a/pages/dev/authoring.dev.tsx
+++ b/pages/dev/authoring.dev.tsx
@@ -234,8 +234,7 @@ const AuthoringPage: NextPage = (): ReactElement => {
   }
 
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 py-10 px-4 sm:px-6">
-      <div className="max-w-4xl mx-auto space-y-8">
+    <div className="space-y-8 pb-12">
         {/* Header */}
         <header className="space-y-3">
           <div className="flex items-center gap-3">
@@ -535,7 +534,6 @@ const AuthoringPage: NextPage = (): ReactElement => {
             )}
           </div>
         )}
-      </div>
     </div>
   )
 }

--- a/pages/dev/authoring.dev.tsx
+++ b/pages/dev/authoring.dev.tsx
@@ -15,9 +15,10 @@ export const getStaticProps: GetStaticProps = async () => {
 type Stage = 'input' | 'generating' | 'preview' | 'publishing' | 'done'
 
 const AuthoringPage: NextPage = (): ReactElement => {
-  // ── Prompt editor ─────────────────────────────────────────────────────
-  const [prompt, setPrompt] = useState('')
-  const [promptDirty, setPromptDirty] = useState(false)
+  // ── Inputs ────────────────────────────────────────────────────────────
+  const [topic, setTopic] = useState('')
+  const [additionalInstruction, setAdditionalInstruction] = useState('')
+  const [corePrompt, setCorePrompt] = useState('')
   const [promptLoading, setPromptLoading] = useState(true)
   const [promptLoadError, setPromptLoadError] = useState('')
 
@@ -70,26 +71,25 @@ const AuthoringPage: NextPage = (): ReactElement => {
   }
   useEffect(() => () => stopTimer(), [])
 
-  // ── Fetch default prompt on mount ──────────────────────────────────────
-  async function fetchDefaultPrompt() {
+  // ── Fetch core prompt on mount (read-only reference) ──────────────────
+  async function fetchCorePrompt() {
     setPromptLoading(true)
     setPromptLoadError('')
     try {
       const res = await fetch('/api/dev/default-prompt')
       const data = await res.json()
       if (!res.ok) {
-        setPromptLoadError(data.error ?? '기본 프롬프트를 불러오지 못했습니다.')
+        setPromptLoadError(data.error ?? 'Core 프롬프트를 불러오지 못했습니다.')
         return
       }
-      setPrompt(data.prompt as string)
-      setPromptDirty(false)
+      setCorePrompt(data.prompt as string)
     } catch (err) {
       setPromptLoadError(err instanceof Error ? err.message : String(err))
     } finally {
       setPromptLoading(false)
     }
   }
-  useEffect(() => { fetchDefaultPrompt() }, [])
+  useEffect(() => { fetchCorePrompt() }, [])
 
   // ── Sync markdown preview ──────────────────────────────────────────────
   useEffect(() => {
@@ -122,7 +122,7 @@ const AuthoringPage: NextPage = (): ReactElement => {
 
   // ── Generate handler ───────────────────────────────────────────────────
   async function handleGenerate() {
-    if (prompt.trim().length < 50) return
+    if (!topic.trim()) return
     setGenerateError('')
     setPublishError('')
     setPublishedUrl('')
@@ -133,7 +133,7 @@ const AuthoringPage: NextPage = (): ReactElement => {
       const res = await fetch('/api/dev/generate-post', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt }),
+        body: JSON.stringify({ topic, additionalInstruction }),
       })
       const data = await res.json()
       if (!res.ok) {
@@ -245,48 +245,67 @@ const AuthoringPage: NextPage = (): ReactElement => {
 
       {/* Section A — Input */}
       {(stage === 'input' || stage === 'generating') && (
-        <div className="space-y-4">
-          <div className="flex items-center justify-between">
-            <label className="block font-semibold" htmlFor="prompt">
-              Codex 프롬프트
+        <div className="space-y-6">
+          {/* Core prompt — read-only reference */}
+          <details className="border rounded p-4">
+            <summary className="cursor-pointer text-sm font-semibold">
+              Core 프롬프트 (참조용 · 읽기 전용)
+            </summary>
+            <div className="mt-3 space-y-2">
+              {promptLoadError && (
+                <div className="flex items-center gap-3 bg-red-50 text-red-700 p-3 rounded text-sm">
+                  <span>{promptLoadError}</span>
+                  <button
+                    type="button"
+                    onClick={fetchCorePrompt}
+                    className="underline cursor-pointer shrink-0"
+                  >
+                    다시 시도
+                  </button>
+                </div>
+              )}
+              <textarea
+                readOnly
+                className="w-full border rounded p-3 font-mono text-xs h-72 resize-y bg-gray-50 text-gray-700"
+                placeholder={promptLoading ? 'Core 프롬프트를 불러오는 중...' : ''}
+                value={corePrompt}
+              />
+              <p className="text-xs text-gray-500">
+                이 영역은 수정할 수 없습니다. 주제와 추가 인스트럭션은 아래 필드에 입력하세요.
+              </p>
+            </div>
+          </details>
+
+          {/* Topic — required */}
+          <div className="space-y-2">
+            <label className="block font-semibold" htmlFor="topic">
+              주제 <span className="text-red-500 text-sm">*</span>
             </label>
-            <div className="flex items-center gap-3">
-              <span className="text-xs text-gray-400">{prompt.length}자</span>
-              <button
-                type="button"
-                onClick={() => {
-                  if (promptDirty) {
-                    if (!window.confirm('편집 내용을 버리고 기본값으로 되돌릴까요?')) return
-                  }
-                  fetchDefaultPrompt()
-                }}
-                disabled={stage === 'generating' || promptLoading}
-                className="text-xs text-blue-500 underline cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
-              >
-                기본값으로 되돌리기
-              </button>
-            </div>
+            <textarea
+              id="topic"
+              className="w-full border rounded p-3 font-mono text-sm h-28 resize-y"
+              placeholder="예: React 19의 useActionState 사용법 정리"
+              value={topic}
+              onChange={(e) => setTopic(e.target.value)}
+              disabled={stage === 'generating'}
+            />
           </div>
-          {promptLoadError && (
-            <div className="flex items-center gap-3 bg-red-50 text-red-700 p-3 rounded text-sm">
-              <span>{promptLoadError}</span>
-              <button
-                type="button"
-                onClick={fetchDefaultPrompt}
-                className="underline cursor-pointer shrink-0"
-              >
-                다시 시도
-              </button>
-            </div>
-          )}
-          <textarea
-            id="prompt"
-            className="w-full border rounded p-3 font-mono text-sm h-[60vh] resize-y"
-            placeholder={promptLoading ? '기본 프롬프트를 불러오는 중...' : '프롬프트를 입력하세요 (최소 50자)'}
-            value={prompt}
-            onChange={(e) => { setPrompt(e.target.value); setPromptDirty(true) }}
-            disabled={stage === 'generating' || promptLoading}
-          />
+
+          {/* Additional instruction — optional */}
+          <div className="space-y-2">
+            <label className="block font-semibold" htmlFor="additional-instruction">
+              추가 인스트럭션 <span className="text-xs text-gray-400">(선택)</span>
+            </label>
+            <textarea
+              id="additional-instruction"
+              className="w-full border rounded p-3 font-mono text-sm h-36 resize-y"
+              placeholder="예: 톤은 캐주얼하게, 길이는 500자 내외, 코드 예제 위주로"
+              value={additionalInstruction}
+              onChange={(e) => setAdditionalInstruction(e.target.value)}
+              disabled={stage === 'generating'}
+            />
+          </div>
+
           {generateError && (
             <pre className="bg-red-50 text-red-700 p-3 rounded text-sm whitespace-pre-wrap overflow-auto">
               {generateError}
@@ -294,7 +313,7 @@ const AuthoringPage: NextPage = (): ReactElement => {
           )}
           <button
             onClick={handleGenerate}
-            disabled={stage === 'generating' || promptLoading || prompt.trim().length < 50}
+            disabled={stage === 'generating' || !topic.trim()}
             className="px-6 py-2 bg-blue-600 text-white rounded disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
           >
             {stage === 'generating' ? '생성 중...' : '생성'}

--- a/pages/dev/authoring.dev.tsx
+++ b/pages/dev/authoring.dev.tsx
@@ -2,7 +2,7 @@ import type { GetStaticProps, NextPage } from 'next'
 import DOMPurify from 'isomorphic-dompurify'
 import { marked } from 'marked'
 import hljs from 'highlight.js'
-import { ChangeEvent, ReactElement, useEffect, useRef, useState } from 'react'
+import { ChangeEvent, ReactElement, ReactNode, useEffect, useRef, useState } from 'react'
 import { CATEGORIES } from '../../config/posts.config'
 import { GeneratedPost, GeneratedPostMetadata } from '../../utils/dev/types'
 
@@ -13,6 +13,12 @@ export const getStaticProps: GetStaticProps = async () => {
 }
 
 type Stage = 'input' | 'generating' | 'preview' | 'publishing' | 'done'
+
+const STAGE_STEPS: { key: Stage[]; label: string }[] = [
+  { key: ['input', 'generating'], label: '입력' },
+  { key: ['preview', 'publishing'], label: '검토' },
+  { key: ['done'], label: '게시' },
+]
 
 const AuthoringPage: NextPage = (): ReactElement => {
   // ── Inputs ────────────────────────────────────────────────────────────
@@ -29,14 +35,13 @@ const AuthoringPage: NextPage = (): ReactElement => {
 
   // ── Generated post (editable) ──────────────────────────────────────────
   const [post, setPost] = useState<GeneratedPost | null>(null)
-  // Editable metadata fields
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
   const [category, setCategory] = useState<keyof typeof CATEGORIES>('javascript')
   const [fileName, setFileName] = useState('')
   const [publishedAt, setPublishedAt] = useState('')
   const [tagsInput, setTagsInput] = useState('')
-  const [refsInput, setRefsInput] = useState('') // JSON array string
+  const [refsInput, setRefsInput] = useState('')
   const [markdown, setMarkdown] = useState('')
 
   // ── Thumbnail ──────────────────────────────────────────────────────────
@@ -103,7 +108,6 @@ const AuthoringPage: NextPage = (): ReactElement => {
     }
   }, [stage, renderedHtml])
 
-  // ── Populate editable fields from generated post ───────────────────────
   function populateFromPost(generated: GeneratedPost) {
     setPost(generated)
     const m = generated.metadata
@@ -120,7 +124,6 @@ const AuthoringPage: NextPage = (): ReactElement => {
     setGeneratePrompt(generated.thumbnail.generatePrompt ?? '')
   }
 
-  // ── Generate handler ───────────────────────────────────────────────────
   async function handleGenerate() {
     if (!topic.trim()) return
     setGenerateError('')
@@ -151,7 +154,6 @@ const AuthoringPage: NextPage = (): ReactElement => {
     }
   }
 
-  // ── File upload handler ────────────────────────────────────────────────
   function handleFileChange(e: ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
     if (!file) return
@@ -159,14 +161,12 @@ const AuthoringPage: NextPage = (): ReactElement => {
     const reader = new FileReader()
     reader.onload = (ev) => {
       const result = ev.target?.result as string
-      // result is data:image/png;base64,XXXX — strip prefix
       const base64 = result.split(',')[1]
       setUploadedBase64(base64)
     }
     reader.readAsDataURL(file)
   }
 
-  // ── Build metadata from editable fields ───────────────────────────────
   function buildMetadata(): GeneratedPostMetadata {
     let refs: { title: string; url: string }[] | undefined
     if (refsInput.trim()) {
@@ -187,7 +187,6 @@ const AuthoringPage: NextPage = (): ReactElement => {
     }
   }
 
-  // ── Publish handler ────────────────────────────────────────────────────
   async function handlePublish() {
     setPublishError('')
     setStage('publishing')
@@ -234,268 +233,460 @@ const AuthoringPage: NextPage = (): ReactElement => {
     }
   }
 
-  // ── Render ─────────────────────────────────────────────────────────────
   return (
-    <div className="max-w-4xl mx-auto p-6 space-y-8">
-      {/* Header */}
-      <div className="border-b pb-4">
-        <h1 className="text-2xl font-bold">글 작성 (Dev only)</h1>
-        <p className="text-sm text-gray-500 mt-1">이 페이지는 production export에 포함되지 않습니다.</p>
-      </div>
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 py-10 px-4 sm:px-6">
+      <div className="max-w-4xl mx-auto space-y-8">
+        {/* Header */}
+        <header className="space-y-3">
+          <div className="flex items-center gap-3">
+            <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold tracking-wide bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
+              <span className="w-1.5 h-1.5 rounded-full bg-amber-500" />
+              DEV ONLY
+            </span>
+            <span className="text-xs text-slate-500 dark:text-slate-400">production export에 포함되지 않습니다</span>
+          </div>
+          <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-50">Codex 글 작성</h1>
+          <Stepper stage={stage} />
+        </header>
 
-      {/* Section A — Input */}
-      {(stage === 'input' || stage === 'generating') && (
-        <div className="space-y-6">
-          {/* Core prompt — read-only reference */}
-          <details className="border rounded p-4">
-            <summary className="cursor-pointer text-sm font-semibold">
-              Core 프롬프트 (참조용 · 읽기 전용)
-            </summary>
-            <div className="mt-3 space-y-2">
-              {promptLoadError && (
-                <div className="flex items-center gap-3 bg-red-50 text-red-700 p-3 rounded text-sm">
-                  <span>{promptLoadError}</span>
-                  <button
-                    type="button"
-                    onClick={fetchCorePrompt}
-                    className="underline cursor-pointer shrink-0"
-                  >
-                    다시 시도
-                  </button>
+        {/* Section A — Input */}
+        {(stage === 'input' || stage === 'generating') && (
+          <div className="space-y-6">
+            {/* Core prompt — read-only reference */}
+            <Card>
+              <details className="group">
+                <summary className="flex items-center justify-between cursor-pointer list-none -m-6 p-6 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-800/50 transition">
+                  <div className="flex items-center gap-3">
+                    <span className="text-xs font-mono px-2 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300">READ-ONLY</span>
+                    <span className="font-semibold text-slate-800 dark:text-slate-100">Core 프롬프트</span>
+                    <span className="text-xs text-slate-500 dark:text-slate-400">참조용</span>
+                  </div>
+                  <Chevron />
+                </summary>
+                <div className="mt-4 space-y-3">
+                  {promptLoadError && (
+                    <Alert tone="error">
+                      <span>{promptLoadError}</span>
+                      <button
+                        type="button"
+                        onClick={fetchCorePrompt}
+                        className="underline font-medium cursor-pointer shrink-0"
+                      >
+                        다시 시도
+                      </button>
+                    </Alert>
+                  )}
+                  <textarea
+                    readOnly
+                    className="w-full border border-slate-200 dark:border-slate-700 rounded-lg p-4 font-mono text-xs leading-relaxed h-80 resize-y bg-slate-50 dark:bg-slate-900 text-slate-600 dark:text-slate-300 focus:outline-none"
+                    placeholder={promptLoading ? 'Core 프롬프트를 불러오는 중...' : ''}
+                    value={corePrompt}
+                  />
+                  <p className="text-xs text-slate-500 dark:text-slate-400 flex items-center gap-1.5">
+                    <LockIcon />
+                    이 영역은 수정할 수 없습니다. 주제와 추가 인스트럭션은 아래 필드에 입력하세요.
+                  </p>
                 </div>
-              )}
-              <textarea
-                readOnly
-                className="w-full border rounded p-3 font-mono text-xs h-72 resize-y bg-gray-50 text-gray-700"
-                placeholder={promptLoading ? 'Core 프롬프트를 불러오는 중...' : ''}
-                value={corePrompt}
-              />
-              <p className="text-xs text-gray-500">
-                이 영역은 수정할 수 없습니다. 주제와 추가 인스트럭션은 아래 필드에 입력하세요.
-              </p>
-            </div>
-          </details>
+              </details>
+            </Card>
 
-          {/* Topic — required */}
-          <div className="space-y-2">
-            <label className="block font-semibold" htmlFor="topic">
-              주제 <span className="text-red-500 text-sm">*</span>
-            </label>
-            <textarea
-              id="topic"
-              className="w-full border rounded p-3 font-mono text-sm h-28 resize-y"
-              placeholder="예: React 19의 useActionState 사용법 정리"
-              value={topic}
-              onChange={(e) => setTopic(e.target.value)}
-              disabled={stage === 'generating'}
-            />
-          </div>
-
-          {/* Additional instruction — optional */}
-          <div className="space-y-2">
-            <label className="block font-semibold" htmlFor="additional-instruction">
-              추가 인스트럭션 <span className="text-xs text-gray-400">(선택)</span>
-            </label>
-            <textarea
-              id="additional-instruction"
-              className="w-full border rounded p-3 font-mono text-sm h-36 resize-y"
-              placeholder="예: 톤은 캐주얼하게, 길이는 500자 내외, 코드 예제 위주로"
-              value={additionalInstruction}
-              onChange={(e) => setAdditionalInstruction(e.target.value)}
-              disabled={stage === 'generating'}
-            />
-          </div>
-
-          {generateError && (
-            <pre className="bg-red-50 text-red-700 p-3 rounded text-sm whitespace-pre-wrap overflow-auto">
-              {generateError}
-            </pre>
-          )}
-          <button
-            onClick={handleGenerate}
-            disabled={stage === 'generating' || !topic.trim()}
-            className="px-6 py-2 bg-blue-600 text-white rounded disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
-          >
-            {stage === 'generating' ? '생성 중...' : '생성'}
-          </button>
-        </div>
-      )}
-
-      {/* Section B — Generating spinner */}
-      {stage === 'generating' && (
-        <div className="flex items-center gap-4 text-gray-600">
-          <div className="w-6 h-6 border-4 border-blue-400 border-t-transparent rounded-full animate-spin" />
-          <span>Codex가 포스트를 작성하는 중입니다… ({elapsedSeconds}초)</span>
-        </div>
-      )}
-
-      {/* Section C — Preview */}
-      {(stage === 'preview' || stage === 'publishing' || stage === 'done') && (
-        <div className="space-y-8">
-          {/* Back button */}
-          {stage === 'preview' && (
-            <button
-              onClick={() => setStage('input')}
-              className="text-sm text-blue-600 underline cursor-pointer"
-            >
-              ← 다시 작성
-            </button>
-          )}
-
-          {/* Metadata editor */}
-          <details open className="border rounded p-4 space-y-4">
-            <summary className="font-semibold cursor-pointer">메타데이터 편집</summary>
-            <div className="space-y-3 mt-3">
-              <Field label="제목">
-                <input className="w-full border rounded p-2 text-sm" value={title} onChange={(e) => setTitle(e.target.value)} />
-              </Field>
-              <Field label="설명">
-                <textarea className="w-full border rounded p-2 text-sm h-20 resize-y" value={description} onChange={(e) => setDescription(e.target.value)} />
-              </Field>
-              <Field label="카테고리">
-                <select
-                  className="border rounded p-2 text-sm"
-                  value={category}
-                  onChange={(e) => setCategory(e.target.value as keyof typeof CATEGORIES)}
-                >
-                  {Object.entries(CATEGORIES).map(([key, val]) => (
-                    <option key={key} value={key}>{key} — {val}</option>
-                  ))}
-                </select>
-              </Field>
-              <Field label="fileName">
-                <input className="w-full border rounded p-2 text-sm font-mono" value={fileName} onChange={(e) => setFileName(e.target.value)} />
-              </Field>
-              <Field label="publishedAt">
-                <input type="date" className="border rounded p-2 text-sm" value={publishedAt} onChange={(e) => setPublishedAt(e.target.value)} />
-              </Field>
-              <Field label="태그 (쉼표 구분)">
-                <input className="w-full border rounded p-2 text-sm" value={tagsInput} onChange={(e) => setTagsInput(e.target.value)} />
-              </Field>
-              <Field label="references (JSON 배열)">
+            {/* Topic — required */}
+            <Card>
+              <div className="space-y-2">
+                <div className="flex items-baseline justify-between">
+                  <label className="text-sm font-semibold text-slate-800 dark:text-slate-100" htmlFor="topic">
+                    주제
+                    <span className="ml-1.5 text-red-500" aria-label="required">*</span>
+                  </label>
+                  <span className="text-xs text-slate-400 dark:text-slate-500">{topic.length}자</span>
+                </div>
                 <textarea
-                  className="w-full border rounded p-2 text-sm font-mono h-28 resize-y"
-                  value={refsInput}
-                  onChange={(e) => setRefsInput(e.target.value)}
-                  placeholder='[{"title":"...", "url":"..."}]'
+                  id="topic"
+                  className="w-full border border-slate-200 dark:border-slate-700 rounded-lg p-3 text-sm h-24 resize-y bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+                  placeholder="예: React 19의 useActionState 사용법 정리"
+                  value={topic}
+                  onChange={(e) => setTopic(e.target.value)}
+                  disabled={stage === 'generating'}
                 />
-              </Field>
-            </div>
-          </details>
-
-          {/* Thumbnail */}
-          <details open className="border rounded p-4 space-y-4">
-            <summary className="font-semibold cursor-pointer">썸네일</summary>
-            <div className="mt-3 space-y-3">
-              <div className="flex gap-4 items-center">
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input type="radio" value="reuse" checked={thumbnailMode === 'reuse'} onChange={() => setThumbnailMode('reuse')} />
-                  기존 파일 재사용
-                </label>
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input type="radio" value="generate" checked={thumbnailMode === 'generate'} onChange={() => setThumbnailMode('generate')} />
-                  이미지 업로드 (직접 제공)
-                </label>
               </div>
-              {thumbnailMode === 'reuse' && (
-                <div className="space-y-2">
-                  <input
-                    className="w-full border rounded p-2 text-sm"
-                    value={reuseFileName}
-                    onChange={(e) => setReuseFileName(e.target.value)}
-                    placeholder="예: react-thumbnail.png"
-                  />
-                  {reuseFileName && (
-                    <img
-                      src={`/assets/images/${reuseFileName}`}
-                      alt="thumbnail preview"
-                      className="h-32 object-contain border rounded"
+            </Card>
+
+            {/* Additional instruction — optional */}
+            <Card>
+              <div className="space-y-2">
+                <div className="flex items-baseline justify-between">
+                  <label className="text-sm font-semibold text-slate-800 dark:text-slate-100" htmlFor="additional-instruction">
+                    추가 인스트럭션
+                    <span className="ml-1.5 text-xs font-normal text-slate-400 dark:text-slate-500">선택</span>
+                  </label>
+                  <span className="text-xs text-slate-400 dark:text-slate-500">{additionalInstruction.length}자</span>
+                </div>
+                <textarea
+                  id="additional-instruction"
+                  className="w-full border border-slate-200 dark:border-slate-700 rounded-lg p-3 text-sm h-32 resize-y bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+                  placeholder="예: 톤은 캐주얼하게, 길이는 500자 내외, 코드 예제 위주로"
+                  value={additionalInstruction}
+                  onChange={(e) => setAdditionalInstruction(e.target.value)}
+                  disabled={stage === 'generating'}
+                />
+              </div>
+            </Card>
+
+            {generateError && (
+              <Alert tone="error" block>
+                <pre className="whitespace-pre-wrap font-mono text-xs overflow-auto">{generateError}</pre>
+              </Alert>
+            )}
+
+            {/* Generating state */}
+            {stage === 'generating' ? (
+              <Card>
+                <div className="flex items-center gap-4 py-2">
+                  <Spinner color="blue" />
+                  <div className="flex-1">
+                    <p className="font-medium text-slate-800 dark:text-slate-100">Codex가 포스트를 작성하는 중...</p>
+                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">경과 시간 {elapsedSeconds}초</p>
+                  </div>
+                </div>
+              </Card>
+            ) : (
+              <div className="flex justify-end">
+                <PrimaryButton onClick={handleGenerate} disabled={!topic.trim()}>
+                  생성
+                </PrimaryButton>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Section C — Preview */}
+        {(stage === 'preview' || stage === 'publishing' || stage === 'done') && (
+          <div className="space-y-6">
+            {stage === 'preview' && (
+              <button
+                onClick={() => setStage('input')}
+                className="inline-flex items-center gap-1.5 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 cursor-pointer transition"
+              >
+                <span aria-hidden>←</span> 다시 작성
+              </button>
+            )}
+
+            {/* Metadata editor */}
+            <Card>
+              <details open>
+                <summary className="cursor-pointer list-none flex items-center justify-between -m-6 p-6 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-800/50 transition">
+                  <span className="font-semibold text-slate-800 dark:text-slate-100">메타데이터</span>
+                  <Chevron />
+                </summary>
+                <div className="mt-5 grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <Field label="제목" full>
+                    <TextInput value={title} onChange={setTitle} />
+                  </Field>
+                  <Field label="설명" full>
+                    <TextArea value={description} onChange={setDescription} rows={3} />
+                  </Field>
+                  <Field label="카테고리">
+                    <select
+                      className={inputClass}
+                      value={category}
+                      onChange={(e) => setCategory(e.target.value as keyof typeof CATEGORIES)}
+                    >
+                      {Object.entries(CATEGORIES).map(([key, val]) => (
+                        <option key={key} value={key}>{key} — {val}</option>
+                      ))}
+                    </select>
+                  </Field>
+                  <Field label="publishedAt">
+                    <input type="date" className={inputClass} value={publishedAt} onChange={(e) => setPublishedAt(e.target.value)} />
+                  </Field>
+                  <Field label="fileName" full>
+                    <TextInput value={fileName} onChange={setFileName} mono />
+                  </Field>
+                  <Field label="태그 (쉼표 구분)" full>
+                    <TextInput value={tagsInput} onChange={setTagsInput} />
+                  </Field>
+                  <Field label="references (JSON 배열)" full>
+                    <TextArea
+                      value={refsInput}
+                      onChange={setRefsInput}
+                      rows={4}
+                      mono
+                      placeholder='[{"title":"...", "url":"..."}]'
                     />
+                  </Field>
+                </div>
+              </details>
+            </Card>
+
+            {/* Thumbnail */}
+            <Card>
+              <details open>
+                <summary className="cursor-pointer list-none flex items-center justify-between -m-6 p-6 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-800/50 transition">
+                  <span className="font-semibold text-slate-800 dark:text-slate-100">썸네일</span>
+                  <Chevron />
+                </summary>
+                <div className="mt-5 space-y-4">
+                  <div className="flex flex-wrap gap-2">
+                    <RadioPill checked={thumbnailMode === 'reuse'} onChange={() => setThumbnailMode('reuse')}>
+                      기존 파일 재사용
+                    </RadioPill>
+                    <RadioPill checked={thumbnailMode === 'generate'} onChange={() => setThumbnailMode('generate')}>
+                      이미지 업로드
+                    </RadioPill>
+                  </div>
+                  {thumbnailMode === 'reuse' && (
+                    <div className="space-y-3">
+                      <TextInput value={reuseFileName} onChange={setReuseFileName} placeholder="예: react-thumbnail.png" />
+                      {reuseFileName && (
+                        <div className="border border-slate-200 dark:border-slate-700 rounded-lg p-3 bg-slate-50 dark:bg-slate-900">
+                          <img
+                            src={`/assets/images/${reuseFileName}`}
+                            alt="thumbnail preview"
+                            className="h-32 object-contain rounded"
+                          />
+                        </div>
+                      )}
+                    </div>
+                  )}
+                  {thumbnailMode === 'generate' && (
+                    <div className="space-y-3">
+                      {generatePrompt && (
+                        <p className="text-sm text-slate-600 dark:text-slate-400 italic border-l-2 border-slate-300 dark:border-slate-600 pl-3">
+                          Codex 제안: {generatePrompt}
+                        </p>
+                      )}
+                      <input
+                        type="file"
+                        accept="image/*"
+                        onChange={handleFileChange}
+                        className="text-sm text-slate-600 dark:text-slate-300 file:mr-3 file:py-1.5 file:px-3 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-blue-50 dark:file:bg-blue-900/40 file:text-blue-700 dark:file:text-blue-300 hover:file:bg-blue-100 dark:hover:file:bg-blue-900/60 file:cursor-pointer"
+                      />
+                      {uploadedFile && (
+                        <p className="text-xs text-slate-500 dark:text-slate-400">
+                          <span className="font-medium">{uploadedFile.name}</span> · {Math.round(uploadedFile.size / 1024)}KB
+                        </p>
+                      )}
+                    </div>
                   )}
                 </div>
-              )}
-              {thumbnailMode === 'generate' && (
-                <div className="space-y-2">
-                  <p className="text-sm text-gray-600">Codex 제안 프롬프트: <em>{generatePrompt}</em></p>
-                  <input
-                    type="file"
-                    accept="image/*"
-                    onChange={handleFileChange}
-                    className="text-sm"
-                  />
-                  {uploadedFile && (
-                    <p className="text-xs text-gray-500">{uploadedFile.name} ({Math.round(uploadedFile.size / 1024)}KB) 선택됨</p>
-                  )}
+              </details>
+            </Card>
+
+            {/* Markdown editor */}
+            <Card>
+              <h2 className="font-semibold text-slate-800 dark:text-slate-100 mb-3">본문</h2>
+              <textarea
+                className="w-full border border-slate-200 dark:border-slate-700 rounded-lg p-3 font-mono text-sm h-72 resize-y bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition leading-relaxed"
+                value={markdown}
+                onChange={(e) => setMarkdown(e.target.value)}
+              />
+            </Card>
+
+            {/* Preview */}
+            <Card>
+              <h2 className="font-semibold text-slate-800 dark:text-slate-100 mb-3">미리보기</h2>
+              <div
+                ref={previewRef}
+                className="prose dark:prose-invert max-w-none post-body border border-slate-200 dark:border-slate-700 rounded-lg p-5 bg-white dark:bg-slate-900"
+                dangerouslySetInnerHTML={{ __html: renderedHtml }}
+              />
+            </Card>
+
+            {publishError && (
+              <Alert tone="error" block>
+                <pre className="whitespace-pre-wrap font-mono text-xs overflow-auto">{publishError}</pre>
+              </Alert>
+            )}
+
+            {stage === 'done' && publishedUrl && (
+              <Card>
+                <div className="flex items-start gap-3">
+                  <div className="shrink-0 w-10 h-10 rounded-full bg-green-100 dark:bg-green-900/40 flex items-center justify-center">
+                    <CheckIcon />
+                  </div>
+                  <div className="flex-1 space-y-1">
+                    <p className="font-semibold text-slate-800 dark:text-slate-100">게시 완료!</p>
+                    <p className="text-sm text-slate-600 dark:text-slate-300">
+                      <a href={publishedUrl} className="text-blue-600 dark:text-blue-400 hover:underline break-all">
+                        {publishedUrl}
+                      </a>
+                    </p>
+                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-2">
+                      변경 사항을 커밋해 주세요 — <code className="px-1 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-[11px]">posts/</code>, <code className="px-1 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-[11px]">config/posts.config.ts</code>, 썸네일 업로드 시 <code className="px-1 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-[11px]">public/assets/images/</code>
+                    </p>
+                  </div>
                 </div>
-              )}
-            </div>
-          </details>
+              </Card>
+            )}
 
-          {/* Markdown editor + preview */}
-          <div className="space-y-4">
-            <h2 className="font-semibold">본문 편집</h2>
-            <textarea
-              className="w-full border rounded p-3 font-mono text-sm h-64 resize-y"
-              value={markdown}
-              onChange={(e) => setMarkdown(e.target.value)}
-            />
+            {stage === 'preview' && (
+              <div className="flex justify-end">
+                <PrimaryButton onClick={handlePublish} tone="green">게시</PrimaryButton>
+              </div>
+            )}
+
+            {stage === 'publishing' && (
+              <Card>
+                <div className="flex items-center gap-4 py-2">
+                  <Spinner color="green" />
+                  <p className="font-medium text-slate-800 dark:text-slate-100">게시 중...</p>
+                </div>
+              </Card>
+            )}
           </div>
-
-          <div className="space-y-2">
-            <h2 className="font-semibold">미리보기</h2>
-            <div
-              ref={previewRef}
-              className="prose max-w-none post-body border rounded p-4"
-              dangerouslySetInnerHTML={{ __html: renderedHtml }}
-            />
-          </div>
-
-          {/* Errors & publish */}
-          {publishError && (
-            <pre className="bg-red-50 text-red-700 p-3 rounded text-sm whitespace-pre-wrap overflow-auto">
-              {publishError}
-            </pre>
-          )}
-
-          {stage === 'done' && publishedUrl && (
-            <div className="bg-green-50 text-green-800 p-4 rounded">
-              <p className="font-semibold">게시 완료!</p>
-              <p className="text-sm mt-1">
-                <a href={publishedUrl} className="underline">{publishedUrl}</a> 에서 확인하세요.
-              </p>
-              <p className="text-xs text-gray-500 mt-2">
-                변경 사항을 커밋해 주세요: posts/, config/posts.config.ts, public/assets/images/ (썸네일 업로드 시)
-              </p>
-            </div>
-          )}
-
-          {stage === 'preview' && (
-            <button
-              onClick={handlePublish}
-              className="px-6 py-2 bg-green-600 text-white rounded cursor-pointer"
-            >
-              게시
-            </button>
-          )}
-
-          {stage === 'publishing' && (
-            <div className="flex items-center gap-2 text-gray-600">
-              <div className="w-5 h-5 border-4 border-green-400 border-t-transparent rounded-full animate-spin" />
-              <span>게시 중...</span>
-            </div>
-          )}
-        </div>
-      )}
+        )}
+      </div>
     </div>
   )
 }
 
-function Field({ label, children }: { label: string; children: ReactElement }) {
+// ── Subcomponents ────────────────────────────────────────────────────────
+
+const inputClass = 'w-full border border-slate-200 dark:border-slate-700 rounded-lg p-2.5 text-sm bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition'
+
+function Card({ children }: { children: ReactNode }) {
   return (
-    <div>
-      <label className="block text-sm font-medium text-gray-700 mb-1">{label}</label>
+    <section className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl p-6 shadow-sm">
+      {children}
+    </section>
+  )
+}
+
+function Field({ label, full, children }: { label: string; full?: boolean; children: ReactElement }) {
+  return (
+    <div className={full ? 'md:col-span-2' : ''}>
+      <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1.5">{label}</label>
       {children}
     </div>
+  )
+}
+
+function TextInput({
+  value, onChange, placeholder, mono,
+}: { value: string; onChange: (v: string) => void; placeholder?: string; mono?: boolean }) {
+  return (
+    <input
+      className={`${inputClass} ${mono ? 'font-mono' : ''}`}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+    />
+  )
+}
+
+function TextArea({
+  value, onChange, rows = 3, mono, placeholder,
+}: { value: string; onChange: (v: string) => void; rows?: number; mono?: boolean; placeholder?: string }) {
+  return (
+    <textarea
+      className={`${inputClass} resize-y ${mono ? 'font-mono' : ''}`}
+      style={{ minHeight: `${rows * 1.75}rem` }}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+    />
+  )
+}
+
+function PrimaryButton({
+  children, onClick, disabled, tone = 'blue',
+}: { children: ReactNode; onClick: () => void; disabled?: boolean; tone?: 'blue' | 'green' }) {
+  const colors = tone === 'green'
+    ? 'bg-green-600 hover:bg-green-700 active:bg-green-800'
+    : 'bg-blue-600 hover:bg-blue-700 active:bg-blue-800'
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={`${colors} px-6 py-2.5 text-white font-medium rounded-lg shadow-sm transition cursor-pointer disabled:bg-slate-300 dark:disabled:bg-slate-700 disabled:cursor-not-allowed disabled:shadow-none`}
+    >
+      {children}
+    </button>
+  )
+}
+
+function RadioPill({ checked, onChange, children }: { checked: boolean; onChange: () => void; children: ReactNode }) {
+  return (
+    <label className={`inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full border cursor-pointer text-sm transition ${
+      checked
+        ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
+        : 'border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:border-slate-300 dark:hover:border-slate-600'
+    }`}>
+      <input type="radio" checked={checked} onChange={onChange} className="sr-only" />
+      <span className={`w-2 h-2 rounded-full ${checked ? 'bg-blue-500' : 'bg-slate-300 dark:bg-slate-600'}`} />
+      {children}
+    </label>
+  )
+}
+
+function Alert({ tone, block, children }: { tone: 'error'; block?: boolean; children: ReactNode }) {
+  const toneClasses = tone === 'error'
+    ? 'bg-red-50 dark:bg-red-950/40 border-red-200 dark:border-red-900 text-red-700 dark:text-red-300'
+    : ''
+  return (
+    <div className={`border rounded-lg p-3 text-sm ${toneClasses} ${block ? '' : 'flex items-center gap-3'}`}>
+      {children}
+    </div>
+  )
+}
+
+function Spinner({ color }: { color: 'blue' | 'green' }) {
+  const c = color === 'green' ? 'border-green-500' : 'border-blue-500'
+  return <div className={`w-6 h-6 border-[3px] ${c} border-t-transparent rounded-full animate-spin`} />
+}
+
+function Chevron() {
+  return (
+    <svg className="w-4 h-4 text-slate-400 transition-transform group-open:rotate-180" viewBox="0 0 20 20" fill="currentColor" aria-hidden>
+      <path fillRule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.06l3.71-3.83a.75.75 0 111.08 1.04l-4.25 4.39a.75.75 0 01-1.08 0L5.21 8.27a.75.75 0 01.02-1.06z" clipRule="evenodd" />
+    </svg>
+  )
+}
+
+function LockIcon() {
+  return (
+    <svg className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden>
+      <path fillRule="evenodd" d="M10 1a4.5 4.5 0 00-4.5 4.5V9H5a2 2 0 00-2 2v6a2 2 0 002 2h10a2 2 0 002-2v-6a2 2 0 00-2-2h-.5V5.5A4.5 4.5 0 0010 1zm3 8V5.5a3 3 0 10-6 0V9h6z" clipRule="evenodd" />
+    </svg>
+  )
+}
+
+function CheckIcon() {
+  return (
+    <svg className="w-5 h-5 text-green-600 dark:text-green-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden>
+      <path fillRule="evenodd" d="M16.7 5.3a1 1 0 010 1.4l-7.5 7.5a1 1 0 01-1.4 0L3.3 9.7a1 1 0 011.4-1.4L8.5 12l6.8-6.7a1 1 0 011.4 0z" clipRule="evenodd" />
+    </svg>
+  )
+}
+
+function Stepper({ stage }: { stage: Stage }) {
+  const currentIndex = STAGE_STEPS.findIndex((s) => s.key.includes(stage))
+  return (
+    <ol className="flex items-center gap-2 text-xs">
+      {STAGE_STEPS.map((step, i) => {
+        const isActive = i === currentIndex
+        const isDone = i < currentIndex
+        return (
+          <li key={step.label} className="flex items-center gap-2">
+            <span className={`inline-flex items-center justify-center w-6 h-6 rounded-full font-semibold ${
+              isActive
+                ? 'bg-blue-600 text-white'
+                : isDone
+                  ? 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300'
+                  : 'bg-slate-200 dark:bg-slate-800 text-slate-500 dark:text-slate-400'
+            }`}>
+              {isDone ? '✓' : i + 1}
+            </span>
+            <span className={`font-medium ${isActive ? 'text-slate-900 dark:text-slate-100' : 'text-slate-500 dark:text-slate-400'}`}>
+              {step.label}
+            </span>
+            {i < STAGE_STEPS.length - 1 && (
+              <span className={`w-8 h-px ${isDone ? 'bg-blue-300 dark:bg-blue-700' : 'bg-slate-200 dark:bg-slate-700'}`} />
+            )}
+          </li>
+        )
+      })}
+    </ol>
   )
 }
 

--- a/utils/dev/AuthoringPrompt.ts
+++ b/utils/dev/AuthoringPrompt.ts
@@ -6,14 +6,11 @@ if (typeof window !== 'undefined') {
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { CATEGORIES, Post } from '../../config/posts.config'
 import { GENERATED_POST_JSON_SCHEMA } from './types'
 
 export interface AuthoringPromptOptions {
   userInstruction?: string
   today: string               // YYYY-MM-DD — server's local date
-  publishedPosts: Post[]      // from postsDatabase
-  thumbnailFileNames: string[] // files in public/assets/images/
 }
 
 /**
@@ -29,31 +26,37 @@ export function getSchemaFilePath(): string {
 
 /**
  * Build the full prompt string to pass to codex via stdin.
+ *
+ * The prompt references workspace paths instead of embedding data dumps so the
+ * model reads live state (categories, catalog, thumbnails) on each run. Codex
+ * runs with `--sandbox workspace-write` and has read access to the project root.
  */
 export function buildAuthoringPrompt(opts: AuthoringPromptOptions): string {
-  const { userInstruction = '', today, publishedPosts, thumbnailFileNames } = opts
-
-  const categoriesBlock = Object.entries(CATEGORIES)
-    .map(([key, value]) => `  - key: "${key}"  display: "${value}"`)
-    .join('\n')
-
-  const catalogBlock = publishedPosts
-    .map((p) => `  - title: "${p.title}" | category: "${p.category}" | tags: ${p.tags.join(', ')}`)
-    .join('\n')
-
-  const thumbnailsBlock = thumbnailFileNames.map((f) => `  - ${f}`).join('\n')
+  const { userInstruction = '', today } = opts
 
   return `You are a senior technical writer for a Korean developer blog (code-logs).
 Your task: produce exactly ONE complete blog post in JSON that strictly conforms to the provided JSON Schema.
 
-=== CATEGORIES (use the "key" field for the "category" property) ===
-${categoriesBlock}
+=== WORKSPACE LAYOUT (read these files directly to stay current) ===
+- 카테고리 정의 및 발행 카탈로그: \`config/posts.config.ts\`
+  · \`CATEGORIES\` 객체: 카테고리 key → display 매핑. JSON 응답의 \`category\` 필드에는 **key**를 사용한다.
+  · \`posts\` 배열: 발행된 Post 메타데이터. 중복 주제 회피와 references 작성에 활용한다.
+- 마크다운 본문 위치: \`posts/<category-key>/<fileName>.md\`
+- 썸네일 디렉토리: \`public/assets/images/\` (디렉토리를 직접 살펴 재사용할 파일을 고른다)
 
-=== PUBLISHED POST CATALOG (use for references and to avoid duplicate topics) ===
-${catalogBlock}
+=== WORKFLOW ===
+1. \`config/posts.config.ts\`를 읽어 사용 가능한 카테고리 key, 기존 fileName, 기존 제목/태그를 파악한다.
+2. \`public/assets/images/\`를 살펴 주제에 어울리는 썸네일 파일이 있는지 확인한다.
+3. 아래 USER INSTRUCTION을 충족하는 새 포스트를 작성한다.
 
-=== EXISTING THUMBNAIL FILES (prefer reuse; list exact filename when reusing) ===
-${thumbnailsBlock}
+=== Post METADATA 포맷 (자세한 타입은 \`config/posts.config.ts\`의 \`Post\` 참고) ===
+- title: 한국어 제목 (필수)
+- description: 1-2문장 요약 (필수)
+- category: \`CATEGORIES\` 객체의 **key** 중 하나 (필수)
+- fileName: kebab-case, \`.md\`로 끝나는 파일명 (예: "use-action-state.md") — 기존과 중복 금지
+- publishedAt: YYYY-MM-DD 형식
+- tags: 문자열 배열 (최소 1개)
+- references: \`[{ title, url }]\` 배열 (선택)
 
 === STYLE RULES ===
 1. Language: Korean prose (technical terms may remain in English).
@@ -65,15 +68,15 @@ ${thumbnailsBlock}
 
 === fileName RULES ===
 - kebab-case, ends with .md (e.g. "use-action-state.md").
-- Must NOT match any existing fileName in the catalog above.
-- Must NOT contain spaces or uppercase.
+- 공백/대문자 금지.
+- \`config/posts.config.ts\`의 기존 fileName과 중복되지 않아야 한다.
 
 === publishedAt ===
 Use today's date: ${today}
 
 === THUMBNAIL RULES ===
-- Prefer "reuse": pick the most thematically fitting file from the EXISTING THUMBNAIL FILES list and set mode="reuse", reuseFileName=<that filename>.
-- If absolutely nothing fits, set mode="generate" and provide a concise image-generation prompt in generatePrompt.
+- 우선 \`public/assets/images/\`에서 주제에 가장 잘 맞는 기존 파일을 골라 mode="reuse", reuseFileName=<파일명>으로 설정한다.
+- 적합한 파일이 없을 때만 mode="generate"로 두고, 이미지 생성용 prompt를 generatePrompt에 작성한다.
 
 === USER INSTRUCTION ===
 ${userInstruction || '(여기에 작성 지시를 입력하세요)'}

--- a/utils/dev/AuthoringPrompt.ts
+++ b/utils/dev/AuthoringPrompt.ts
@@ -10,7 +10,7 @@ import { CATEGORIES, Post } from '../../config/posts.config'
 import { GENERATED_POST_JSON_SCHEMA } from './types'
 
 export interface AuthoringPromptOptions {
-  userInstruction: string
+  userInstruction?: string
   today: string               // YYYY-MM-DD — server's local date
   publishedPosts: Post[]      // from postsDatabase
   thumbnailFileNames: string[] // files in public/assets/images/
@@ -31,7 +31,7 @@ export function getSchemaFilePath(): string {
  * Build the full prompt string to pass to codex via stdin.
  */
 export function buildAuthoringPrompt(opts: AuthoringPromptOptions): string {
-  const { userInstruction, today, publishedPosts, thumbnailFileNames } = opts
+  const { userInstruction = '', today, publishedPosts, thumbnailFileNames } = opts
 
   const categoriesBlock = Object.entries(CATEGORIES)
     .map(([key, value]) => `  - key: "${key}"  display: "${value}"`)
@@ -76,7 +76,7 @@ Use today's date: ${today}
 - If absolutely nothing fits, set mode="generate" and provide a concise image-generation prompt in generatePrompt.
 
 === USER INSTRUCTION ===
-${userInstruction}
+${userInstruction || '(여기에 작성 지시를 입력하세요)'}
 
 Respond with ONLY valid JSON matching the schema — no markdown fences, no prose outside the JSON.`
 }

--- a/utils/dev/AuthoringPrompt.ts
+++ b/utils/dev/AuthoringPrompt.ts
@@ -9,8 +9,9 @@ import path from 'path'
 import { GENERATED_POST_JSON_SCHEMA } from './types'
 
 export interface AuthoringPromptOptions {
-  userInstruction?: string
-  today: string               // YYYY-MM-DD — server's local date
+  today: string                      // YYYY-MM-DD — server's local date
+  topic?: string                     // post subject — required at generation time
+  additionalInstruction?: string     // optional extra guidance from the user
 }
 
 /**
@@ -24,15 +25,25 @@ export function getSchemaFilePath(): string {
   return schemaFilePath
 }
 
+const TOPIC_PLACEHOLDER = '(여기에 주제가 들어갑니다)'
+const ADDITIONAL_PLACEHOLDER = '(추가 인스트럭션이 비어 있습니다 — 선택)'
+
 /**
  * Build the full prompt string to pass to codex via stdin.
  *
  * The prompt references workspace paths instead of embedding data dumps so the
  * model reads live state (categories, catalog, thumbnails) on each run. Codex
  * runs with `--sandbox workspace-write` and has read access to the project root.
+ *
+ * `topic` and `additionalInstruction` are the only user-editable slots. When
+ * omitted, placeholder strings render so the read-only preview stays readable.
  */
 export function buildAuthoringPrompt(opts: AuthoringPromptOptions): string {
-  const { userInstruction = '', today } = opts
+  const { today, topic, additionalInstruction } = opts
+  const topicBody = topic && topic.trim() ? topic.trim() : TOPIC_PLACEHOLDER
+  const additionalBody = additionalInstruction && additionalInstruction.trim()
+    ? additionalInstruction.trim()
+    : ADDITIONAL_PLACEHOLDER
 
   return `You are a senior technical writer for a Korean developer blog (code-logs).
 Your task: produce exactly ONE complete blog post in JSON that strictly conforms to the provided JSON Schema.
@@ -47,7 +58,7 @@ Your task: produce exactly ONE complete blog post in JSON that strictly conforms
 === WORKFLOW ===
 1. \`config/posts.config.ts\`를 읽어 사용 가능한 카테고리 key, 기존 fileName, 기존 제목/태그를 파악한다.
 2. \`public/assets/images/\`를 살펴 주제에 어울리는 썸네일 파일이 있는지 확인한다.
-3. 아래 USER INSTRUCTION을 충족하는 새 포스트를 작성한다.
+3. 아래 TOPIC을 충족하는 새 포스트를 작성한다. ADDITIONAL INSTRUCTIONS가 있다면 함께 반영한다.
 
 === Post METADATA 포맷 (자세한 타입은 \`config/posts.config.ts\`의 \`Post\` 참고) ===
 - title: 한국어 제목 (필수)
@@ -78,8 +89,11 @@ Use today's date: ${today}
 - 우선 \`public/assets/images/\`에서 주제에 가장 잘 맞는 기존 파일을 골라 mode="reuse", reuseFileName=<파일명>으로 설정한다.
 - 적합한 파일이 없을 때만 mode="generate"로 두고, 이미지 생성용 prompt를 generatePrompt에 작성한다.
 
-=== USER INSTRUCTION ===
-${userInstruction || '(여기에 작성 지시를 입력하세요)'}
+=== TOPIC ===
+${topicBody}
+
+=== ADDITIONAL INSTRUCTIONS ===
+${additionalBody}
 
 Respond with ONLY valid JSON matching the schema — no markdown fences, no prose outside the JSON.`
 }


### PR DESCRIPTION
## 요약
`/dev/authoring` 페이지에서 Codex 호출 입력을 세 영역으로 분리하고 페이지 전반의 디자인을 개편했다. Core 프롬프트(스타일 규칙·워크스페이스 레이아웃·스키마 제약)는 서버 소유의 읽기 전용 영역으로 노출되며, 사용자는 "주제"(필수)와 "추가 인스트럭션"(선택) 두 필드만 편집한다. Core 템플릿은 카탈로그/썸네일 데이터 덤프 대신 워크스페이스 경로(`config/posts.config.ts`, `public/assets/images/`)를 참조하도록 작성해, 새 포스트나 썸네일 추가 시에도 재조립 없이 Codex가 매 실행마다 최신 상태를 직접 읽어가도록 했다. UI는 stepper, 카드 레이아웃, 다크모드 대응, 포커스 링, pill 스타일 라디오 등으로 일관성을 끌어올렸다.

## 변경 사항
- 신규 GET 엔드포인트 `pages/api/dev/default-prompt.dev.ts` — Core 프롬프트(placeholder 적용) 반환, `Cache-Control: no-store`
- `pages/api/dev/generate-post.dev.ts` 요청 바디를 `{ topic, additionalInstruction? }`로 변경, 서버에서 `buildAuthoringPrompt`로 재조립
- `utils/dev/AuthoringPrompt.ts` Core 템플릿을 경로 참조형으로 리팩터링하고, topic / additionalInstruction 두 슬롯으로 분리
- `pages/dev/authoring.dev.tsx` UI 개편:
  - Core 프롬프트 `<details>` 읽기 전용 미리보기 + 주제(필수) + 추가 인스트럭션(선택) 3분할
  - stepper(입력→검토→게시), 카드형 섹션, 다크모드 대응, focus ring, pill 라디오
  - Card / Field / PrimaryButton / RadioPill / Alert / Spinner / Stepper / 아이콘 등 작은 컴포넌트로 재사용성 확보
- `.claude/docs/dev-authoring-pipeline.md` 갱신 — Core 서버 소유 원칙, 경로 참조 규칙, 새 요청 바디 명세

## 관련 이슈
Closes #111

## 테스트 체크리스트
- [ ] `pnpm dev` 후 `/dev/authoring` 접속 시 stepper가 "입력" 단계로 표시되고 다크/라이트 모두 자연스러움
- [ ] Core 프롬프트 `<details>` 펼치면 읽기 전용 textarea에 템플릿이 표시되고 편집 불가
- [ ] 주제만 입력하고 "생성" 클릭 → Codex 실행되고 preview 단계(stepper "검토")로 이동
- [ ] 추가 인스트럭션에 "톤은 캐주얼하게" 등 입력 후 생성 시 결과 톤이 반영됨
- [ ] 주제 비었을 때 "생성" 버튼 disabled
- [ ] Codex가 `config/posts.config.ts`와 `public/assets/images/`를 읽어 카테고리·중복 fileName·재사용 썸네일을 정확히 반영
- [ ] 게시 완료 시 stepper "게시" 단계 + 체크 아이콘 카드 노출
- [ ] `pnpm run build` 성공, `out/api/dev/`가 비어 있음
- [ ] `pnpm run lint` 통과
- [ ] 미리보기에 `<script>` 포함 마크다운 입력 시 실행되지 않음 (DOMPurify 회귀 없음)