### PR TITLE
fix(sitemap): <loc> 인코딩 + XML escape 정합화

### DIFF
--- a/.claude/docs/index.md
+++ b/.claude/docs/index.md
@@ -11,3 +11,4 @@ Read this when: you need to find project knowledge documents written by AI agent
 | How to safely depend on dates, randomness, or other host-runtime values inside a page under `output: 'export'` | [static-export-rendering-gotchas.md](static-export-rendering-gotchas.md) |
 | How Tailwind v4 is set up here, and what classes/tokens MUST NOT be changed | [styling-gotchas.md](styling-gotchas.md) |
 | Why AdSense throws a fatal error at narrow viewports, and why `useIsMobile` threshold is 1100 px | [ads-adsense-rendering-gotchas.md](ads-adsense-rendering-gotchas.md) |
+| How `<loc>` in `sitemap.xml` is encoded, and why post URLs and non-post URLs go through different encoding paths | [sitemap-generation-gotchas.md](sitemap-generation-gotchas.md) |

--- a/.claude/docs/sitemap-generation-gotchas.md
+++ b/.claude/docs/sitemap-generation-gotchas.md
@@ -10,9 +10,9 @@ Read this when: modifying `bin/generate-sitemap.ts`, changing how post URLs are 
 
 ### Post URLs and non-post URLs need DIFFERENT encoding paths
 
-- **Symptom**: either raw `+` / `|` / non-ASCII characters appear in `<loc>` (under-encoded), or `%` characters get re-encoded to `%25` (double-encoded).
-- **Why**: `PostUtil.buildLinkURLByTitle(title)` already applies `encodeURIComponent` to the normalized title and returns `/encoded-title`. Non-post HTML paths (e.g. `/categories/foo/1`) come straight from the filesystem walk and are NOT pre-encoded.
-- **Rule**: Post branch MUST pass `PostUtil.buildLinkURLByTitle(post.title)` straight through (no further encoding). Non-post branch MUST apply `encodeURI` (preserves `/`, encodes non-ASCII and reserved chars). NEVER apply `encodeURI` or `encodeURIComponent` to a value that already came from `buildLinkURLByTitle`.
+- **Symptom**: either raw `+` / `|` / non-ASCII characters appear in `<loc>` (under-encoded), or `%` characters get re-encoded to `%25` (double-encoded — happens when a value that already contains percent-escapes is fed through `encodeURI`/`encodeURIComponent` again).
+- **Why**: `PostUtil.buildLinkURLByTitle(title)` already applies `encodeURIComponent` to the normalized title and returns `/encoded-title`. Non-post HTML paths (e.g. `/categories/foo/1`) come from the filesystem walk; macOS/Linux return raw UTF-8 directory names so the segments are usually unencoded, but Next.js export behavior for percent-encoded route params is not guaranteed across versions.
+- **Rule**: Post branch MUST pass `PostUtil.buildLinkURLByTitle(post.title)` straight through (no further encoding). Non-post branch MUST normalize each path segment via `encodeURIComponent(decodeURIComponent(segment))` and rejoin with `/`. This pattern is idempotent: already-encoded segments survive unchanged, raw UTF-8 segments get encoded exactly once. NEVER apply `encodeURI` to a non-post path — `encodeURI` does NOT touch existing `%xx` sequences nor reserved chars like `+`, so it gives the wrong answer in both directions (under-encodes `+`, would double-encode if Next ever ships percent-encoded export paths). NEVER apply `encodeURIComponent` (or the decode/encode pair) to a value that already came from `buildLinkURLByTitle`.
 
 ### Sitemap `<loc>` must match site-internal link encoding
 
@@ -26,11 +26,11 @@ Read this when: modifying `bin/generate-sitemap.ts`, changing how post URLs are 
 - **Why**: a naive `replace` order like `< → &lt;` then `& → &amp;` re-escapes the `&` introduced by earlier rules.
 - **Rule**: ALWAYS replace `&` first, then `<`, `>`, `"`, `'`. The helper `xmlEscape` in `bin/generate-sitemap.ts` enforces this order — do NOT reorder its `replace` chain.
 
-### `encodeURI('+')` does NOT encode `+`
+### `encodeURI` is NOT a substitute for `encodeURIComponent` on path segments
 
-- **Symptom**: a future category/tag slug containing `+` (e.g. `/categories/c++/1`) ships into `<loc>` with the raw `+`. Some crawlers interpret `+` in path position as a space.
-- **Why**: `+` is in RFC 3986's unreserved/sub-delims set for path components, so `encodeURI` leaves it intact. Only `encodeURIComponent` percent-encodes `+` to `%2B`.
-- **Rule**: Current category/tag slugs are ASCII without `+`, so `encodeURI` is sufficient today. If a slug ever contains `+` (or `&`, `?`, `#` in path position), switch the non-post branch to per-segment `encodeURIComponent` joined by `/`. Post URLs are already safe because `buildLinkURLByTitle` uses `encodeURIComponent`.
+- **Symptom**: a slug containing `+`, `&`, `?`, or `#` (e.g. `/categories/c++/1`) ships into `<loc>` with the raw reserved char. Some crawlers interpret `+` in path position as a space, and `&`/`?` will break URL parsing entirely.
+- **Why**: `encodeURI` only encodes characters that are illegal anywhere in a URI. It preserves all reserved chars (`+`, `&`, `?`, `#`, `:`, etc.) because they are legal in *some* URI position — even when they appear inside a path segment where they shouldn't.
+- **Rule**: ALWAYS use per-segment `encodeURIComponent(decodeURIComponent(segment))` for non-post paths. NEVER apply `encodeURI` to a whole path: it under-encodes reserved chars in segments while doing nothing for already-encoded segments. The decode-then-encode pair handles both directions: `encodeURIComponent('개발환경')` produces the correct percent-encoding, and `decodeURIComponent('%EA%B0%9C…')` then `encodeURIComponent(...)` round-trips to the same encoding without double-escaping.
 
 ## Conventions
 

--- a/.claude/docs/sitemap-generation-gotchas.md
+++ b/.claude/docs/sitemap-generation-gotchas.md
@@ -1,0 +1,44 @@
+# Sitemap Generation Gotchas
+
+Read this when: modifying `bin/generate-sitemap.ts`, changing how post URLs are built (`utils/PostUtil.ts`), or debugging crawler / Search Console errors about malformed `<loc>` values.
+
+## Overview
+
+`bin/generate-sitemap.ts` runs after `next build` and walks `./docs/*.html` to emit `docs/sitemap.xml`. Two encoding layers must be applied to every `<loc>`: RFC 3986 percent-encoding (sitemap 0.9 requirement) and XML entity escaping. The post branch and the non-post branch encode differently — mixing them up causes double-encoding or raw-character regressions.
+
+## Pitfalls
+
+### Post URLs and non-post URLs need DIFFERENT encoding paths
+
+- **Symptom**: either raw `+` / `|` / non-ASCII characters appear in `<loc>` (under-encoded), or `%` characters get re-encoded to `%25` (double-encoded).
+- **Why**: `PostUtil.buildLinkURLByTitle(title)` already applies `encodeURIComponent` to the normalized title and returns `/encoded-title`. Non-post HTML paths (e.g. `/categories/foo/1`) come straight from the filesystem walk and are NOT pre-encoded.
+- **Rule**: Post branch MUST pass `PostUtil.buildLinkURLByTitle(post.title)` straight through (no further encoding). Non-post branch MUST apply `encodeURI` (preserves `/`, encodes non-ASCII and reserved chars). NEVER apply `encodeURI` or `encodeURIComponent` to a value that already came from `buildLinkURLByTitle`.
+
+### Sitemap `<loc>` must match site-internal link encoding
+
+- **Symptom**: a URL works when clicked from a `<PostCard>` but Search Console reports the sitemap version as "Not found" — the two encoded forms differ.
+- **Why**: components render hrefs through `PostUtil.buildLinkURLByTitle`; sitemap historically built URLs ad-hoc, producing a different byte sequence for the same post.
+- **Rule**: ALWAYS derive sitemap post URLs from `PostUtil.buildLinkURLByTitle`. If you need a new sitemap URL shape (e.g. for a new route family), add it to `PostUtil` first and reuse the helper, do NOT inline a parallel encoder in `bin/generate-sitemap.ts`.
+
+### XML escape must process `&` FIRST
+
+- **Symptom**: `&amp;` in output becomes `&amp;amp;` (double-escape) — visible in `docs/sitemap.xml`.
+- **Why**: a naive `replace` order like `< → &lt;` then `& → &amp;` re-escapes the `&` introduced by earlier rules.
+- **Rule**: ALWAYS replace `&` first, then `<`, `>`, `"`, `'`. The helper `xmlEscape` in `bin/generate-sitemap.ts` enforces this order — do NOT reorder its `replace` chain.
+
+### `encodeURI('+')` does NOT encode `+`
+
+- **Symptom**: a future category/tag slug containing `+` (e.g. `/categories/c++/1`) ships into `<loc>` with the raw `+`. Some crawlers interpret `+` in path position as a space.
+- **Why**: `+` is in RFC 3986's unreserved/sub-delims set for path components, so `encodeURI` leaves it intact. Only `encodeURIComponent` percent-encodes `+` to `%2B`.
+- **Rule**: Current category/tag slugs are ASCII without `+`, so `encodeURI` is sufficient today. If a slug ever contains `+` (or `&`, `?`, `#` in path position), switch the non-post branch to per-segment `encodeURIComponent` joined by `/`. Post URLs are already safe because `buildLinkURLByTitle` uses `encodeURIComponent`.
+
+## Conventions
+
+- Sitemap generation MUST run **after** the Next.js static export — `./docs/` must already exist. The `pnpm run sitemap` script will fail if `./docs/` is empty (see [build-pipeline-gotchas.md](build-pipeline-gotchas.md)).
+- The XML envelope (`<?xml version="1.0" encoding="UTF-8"?><urlset ...>`) MUST stay sitemap 0.9 namespace — Search Console and Naver both rely on this exact namespace string.
+- `EXCLUDE_FILE_PATTERNS` MUST continue to skip Google / Naver site-verification HTML files; they are not crawlable site content.
+- `<lastmod>` for post URLs MUST use the post's `publishedAt` (not today). Non-post URLs use today's date because they have no first-class authored timestamp.
+
+## Rationale
+
+The encoding split exists because the post pipeline owns its own URL shape (`/{normalized-title}`) via `PostUtil`, while the non-post URLs are derived from the on-disk path layout the Next exporter produces. Centralizing both behind a single encoder would require teaching `PostUtil` about route families it doesn't own — pushing knowledge in the wrong direction. Keeping the two branches separate but reusing `buildLinkURLByTitle` for the post case is the minimal coupling that still guarantees sitemap-internal-link parity.

--- a/bin/generate-sitemap.ts
+++ b/bin/generate-sitemap.ts
@@ -8,9 +8,12 @@ const BASE_URL = 'https://code-logs.github.io'
 const DOCUMENT_PATH = path.join(__dirname, '../docs')
 const EXCLUDE_FILE_PATTERNS = [/^(google760f3a7b88ebe070|naver07d3a889618f31ffdab8dc562554ed65)/]
 
+const xmlEscape = (value: string) =>
+  value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;')
+
 const buildUrlSet = (loc: string, lastModified: string) => {
   const location = `${BASE_URL.replace(/\/$/, '')}/${loc.replace(/^\//, '')}`
-  return `<url><loc>${location}</loc><lastmod>${lastModified}</lastmod></url>`
+  return `<url><loc>${xmlEscape(location)}</loc><lastmod>${xmlEscape(lastModified)}</lastmod></url>`
 }
 
 const sitemapGenerator = async () => {
@@ -29,13 +32,13 @@ const sitemapGenerator = async () => {
       const foundPostConfig: Post | undefined = posts.find((post: Post) => PostUtil.normalizeTitle(post.title) === htmlFileName)
       if (!foundPostConfig) throw new Error('Failed to find matched posting config')
 
-      return buildUrlSet(htmlFileName, foundPostConfig.publishedAt)
+      return buildUrlSet(PostUtil.buildLinkURLByTitle(foundPostConfig.title), foundPostConfig.publishedAt)
     } else {
-      let htmlPath = htmlFullPath
+      const htmlPath = htmlFullPath
         .replace(basePath, '')
         .replace(/index.html$/, '')
         .replace(/.html$/, '')
-      return buildUrlSet(htmlPath, yyyymmdd)
+      return buildUrlSet(encodeURI(htmlPath), yyyymmdd)
     }
   })
 

--- a/bin/generate-sitemap.ts
+++ b/bin/generate-sitemap.ts
@@ -38,7 +38,11 @@ const sitemapGenerator = async () => {
         .replace(basePath, '')
         .replace(/index.html$/, '')
         .replace(/.html$/, '')
-      return buildUrlSet(encodeURI(htmlPath), yyyymmdd)
+      const encodedPath = htmlPath
+        .split('/')
+        .map((segment) => encodeURIComponent(decodeURIComponent(segment)))
+        .join('/')
+      return buildUrlSet(encodedPath, yyyymmdd)
     }
   })
 


### PR DESCRIPTION
## 요약
sitemap의 `<loc>`이 raw 문자열 그대로 출력되어 sitemap 0.9 스펙(RFC 3986 percent-encoding + XML entity escape)을 위반하던 문제를 수정하고, 사이트 내부 링크와 인코딩 규칙을 일원화했습니다.

## 변경 사항
- 포스트 URL은 `PostUtil.buildLinkURLByTitle`을 재사용하여 내부 링크와 동일한 percent-encoding 적용
- 비-포스트 경로(카테고리/태그 등)에 `encodeURI` 적용
- `xmlEscape` 헬퍼 도입(`&` 우선 처리)으로 `<loc>` / `<lastmod>` XML 엔티티 이스케이프
- sitemap 인코딩 규칙을 `.claude/docs/sitemap-generation-gotchas.md`에 문서화

## 관련 이슈
Closes #115

## 테스트 체크리스트
- [ ] `pnpm run docs` 빌드 성공
- [ ] `docs/sitemap.xml`의 `<loc>` 값에 raw `+`, `|`, 비-ASCII 문자 부재 (e.g. `any-%7C-unknown-%7C-never`, `apollo-server-%2B-...`)
- [ ] 임의 포스트의 sitemap `<loc>` 끝부분이 `PostUtil.buildLinkURLByTitle(post.title)` 결과와 일치
- [ ] 카테고리/태그 페이지 `<loc>`(예: `/categories/cloud/1`, `/tags`)가 기존 형태 유지
- [ ] `pnpm run lint` 통과