### PR TITLE
fix(sitemap): basename 기반 post 매칭 및 정규식 escape 적용

### DIFF
--- a/.claude/docs/sitemap-generation-gotchas.md
+++ b/.claude/docs/sitemap-generation-gotchas.md
@@ -26,6 +26,18 @@ Read this when: modifying `bin/generate-sitemap.ts`, changing how post URLs are 
 - **Why**: a naive `replace` order like `< → &lt;` then `& → &amp;` re-escapes the `&` introduced by earlier rules.
 - **Rule**: ALWAYS replace `&` first, then `<`, `>`, `"`, `'`. The helper `xmlEscape` in `bin/generate-sitemap.ts` enforces this order — do NOT reorder its `replace` chain.
 
+### Post matching MUST key on basename, not on the on-disk relative path
+
+- **Symptom**: a post HTML emitted under a subdirectory (e.g. `docs/posts/some-title.html` instead of `docs/some-title.html`) gets `<lastmod>` set to today instead of its `publishedAt`. Search Console then re-crawls the post on every deploy.
+- **Why**: the match key between the filesystem walk and `posts.config.ts` is the normalized post title (`PostUtil.normalizeTitle`). If the lookup key is derived from the full relative path (e.g. `posts/some-title`), it can never equal the normalized title (`some-title`) and the file falls through to the non-post branch.
+- **Rule**: ALWAYS derive the post-match key with `path.basename(htmlFullPath, '.html')` so the match is independent of which directory the static export drops the HTML into. The post URL itself still comes from `PostUtil.buildLinkURLByTitle(post.title)` — the on-disk directory is never used to build `<loc>`, only to enumerate which HTML files exist.
+
+### Strip `index.html` BEFORE `.html` in the non-post branch
+
+- **Symptom**: a category listing emitted as `docs/categories/foo/index.html` shows up in `sitemap.xml` as `/categories/foo/index` (no trailing slash, with the literal segment `index`) instead of `/categories/foo/`.
+- **Why**: the non-post path is normalized by chaining `.replace(/index\.html$/, '').replace(/\.html$/, '')`. If the order is swapped, `.html` strips first and leaves `/categories/foo/index`, which no longer matches `/index\.html$/`.
+- **Rule**: ALWAYS run the `index.html` strip before the generic `.html` strip. The two `replace` calls are order-dependent — do NOT reorder or merge them into one regex.
+
 ### `encodeURI` is NOT a substitute for `encodeURIComponent` on path segments
 
 - **Symptom**: a slug containing `+`, `&`, `?`, or `#` (e.g. `/categories/c++/1`) ships into `<loc>` with the raw reserved char. Some crawlers interpret `+` in path position as a space, and `&`/`?` will break URL parsing entirely.

--- a/bin/generate-sitemap.ts
+++ b/bin/generate-sitemap.ts
@@ -22,22 +22,19 @@ const sitemapGenerator = async () => {
   const normalizedPostTiles = new Set(posts.map((post: Post) => `${PostUtil.normalizeTitle(post.title)}`))
 
   const urlSets = htmlFullPathList.map((htmlFullPath) => {
-    const basePath = path.join(__dirname, '../docs')
-    const htmlFileName = htmlFullPath.replace(/.+docs\/|.html$/g, '')
-    const isPostingHtml = normalizedPostTiles.has(htmlFileName)
+    const htmlBaseName = path.basename(htmlFullPath, '.html')
+    const isPostingHtml = normalizedPostTiles.has(htmlBaseName)
     const today = new Date()
     const yyyymmdd = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
 
     if (isPostingHtml) {
-      const foundPostConfig: Post | undefined = posts.find((post: Post) => PostUtil.normalizeTitle(post.title) === htmlFileName)
+      const foundPostConfig: Post | undefined = posts.find((post: Post) => PostUtil.normalizeTitle(post.title) === htmlBaseName)
       if (!foundPostConfig) throw new Error('Failed to find matched posting config')
 
       return buildUrlSet(PostUtil.buildLinkURLByTitle(foundPostConfig.title), foundPostConfig.publishedAt)
     } else {
-      const htmlPath = htmlFullPath
-        .replace(basePath, '')
-        .replace(/index.html$/, '')
-        .replace(/.html$/, '')
+      const relativePath = path.relative(DOCUMENT_PATH, htmlFullPath).split(path.sep).join('/')
+      const htmlPath = `/${relativePath}`.replace(/index\.html$/, '').replace(/\.html$/, '')
       const encodedPath = htmlPath
         .split('/')
         .map((segment) => encodeURIComponent(decodeURIComponent(segment)))


### PR DESCRIPTION
## 요약
`bin/generate-sitemap.ts`의 post 매칭 키를 파일명(basename) 기반으로 변경하여, 하위 디렉토리로 이동된 post HTML도 올바른 `publishedAt` lastmod를 유지하도록 하였습니다. 또한 정규식의 `.` 메타문자를 escape하고 경로 추출을 명시화했습니다. sitemap.xml 출력은 변경 전과 byte-identical입니다.

## 변경 사항
- post 매칭 키: `path.basename(htmlFullPath, '.html')` 사용 → 디렉토리 위치 무관
- 경로 추출: `path.relative(DOCUMENT_PATH, htmlFullPath)` + `path.sep→'/'` 정규화
- 정규식 escape: `/index\.html$/`, `/\.html$/` 적용
- 불필요한 로컬 `basePath` 변수 제거 → `DOCUMENT_PATH` 재사용
- sitemap-generation-gotchas 문서에 basename invariant 및 replace 순서 의존성 명시

## 관련 이슈
Closes #116

## 테스트 체크리스트
- [x] `pnpm run docs` 후 sitemap.xml이 변경 전 baseline과 동일 (`diff` 비교)
- [x] `pnpm run lint` 통과
- [x] post 매칭이 basename 기반으로 동작 (코드 인스펙션)