### PR TITLE
fix(post): 제목 URL 예약문자 슬러그 처리로 404 해결

### DIFF
--- a/.claude/docs/index.md
+++ b/.claude/docs/index.md
@@ -12,3 +12,4 @@ Read this when: you need to find project knowledge documents written by AI agent
 | How Tailwind v4 is set up here, and what classes/tokens MUST NOT be changed | [styling-gotchas.md](styling-gotchas.md) |
 | Why AdSense throws a fatal error at narrow viewports, and why `useIsMobile` threshold is 1100 px | [ads-adsense-rendering-gotchas.md](ads-adsense-rendering-gotchas.md) |
 | How `<loc>` in `sitemap.xml` is encoded, and why post URLs and non-post URLs go through different encoding paths | [sitemap-generation-gotchas.md](sitemap-generation-gotchas.md) |
+| Which characters `PostUtil.normalizeTitle` strips and why, or why a `?`/`#` in a post title 404s | [post-slug-normalization-gotchas.md](post-slug-normalization-gotchas.md) |

--- a/.claude/docs/post-slug-normalization-gotchas.md
+++ b/.claude/docs/post-slug-normalization-gotchas.md
@@ -1,0 +1,55 @@
+# Post Slug Normalization Gotchas
+
+Read this when: editing `utils/PostUtil.ts` `normalizeTitle` / `buildLinkURLByTitle`, adding a post whose title contains punctuation, or debugging post-detail 404s on GitHub Pages.
+
+## Overview
+
+`PostUtil.normalizeTitle` is the single source of truth for post slugs. Every consumer (`getStaticPaths`, `findByTitle`, `findByNormalizedTitle`, sitemap matcher, internal link builders) goes through it, so a one-line change here shifts every URL the site emits. Two failure modes dominate: leaving truly URL-breaking characters in the slug, and stripping characters aggressively enough to change slugs of already-published posts.
+
+## Pitfalls
+
+### Reserved URL chars in titles produce 404 on the static export
+
+- **Symptom**: a post whose title contains `?`, `#`, `/`, `\`, or `%` (e.g. `Harness Engineering이 뭐지?`) builds a file like `…뭐지?.html` under `./docs/`, but the dev server and GitHub Pages return 404 when navigating to it.
+- **Why**: `?` is parsed as the query-string delimiter by every HTTP server before any file lookup happens, so `/슬러그?` can never reach the file `슬러그?.html`. `#` is dropped from the request before it leaves the browser. `/` and `\` are path separators. `%` triggers percent-decoding ambiguity (`%3F` decodes back to `?`).
+- **Rule**: `normalizeTitle` MUST strip `[?#/\\%]` before lowercasing. Do not extend this set without first auditing existing post titles — see the backward-compatibility pitfall below.
+
+### Whitelist normalization breaks backward compatibility on live posts
+
+- **Symptom**: switching `normalizeTitle` to a `[^a-z0-9가-힣-]`-style whitelist changes the slug for already-published posts that contain `(`, `)`, `:`, `|`, `+`, `,`, etc. After deploy, those posts return 404 because the emitted filename no longer matches indexed URLs and external links.
+- **Why**: those characters are not URL-reserved in path position and the existing GitHub Pages routing serves files containing them. The bug is specific to `?#/\\%`. A whitelist trims everything else as collateral damage.
+- **Rule**: ALWAYS use a denylist (`[?#/\\%]`) rather than a whitelist when extending normalization. Before adding any character to the denylist, run the audit script (see Conventions) over `config/posts.config.ts` and confirm zero slug changes.
+
+### `<CommonMeta url={...}>` must apply percent-encoding
+
+- **Symptom**: canonical URL in the post detail page's `<link rel="canonical">` contains raw non-ASCII characters or other unencoded bytes; some crawlers reject it.
+- **Why**: building the URL as `` `${baseURL}/${normalizeTitle(title)}` `` skips the `encodeURIComponent` step that `buildLinkURLByTitle` performs. `normalizeTitle` returns a Unicode slug — it does not percent-encode.
+- **Rule**: ALWAYS build absolute post URLs as `` `${blogConfig.baseURL}${PostUtil.buildLinkURLByTitle(post.title)}` `` (no extra `/` — `buildLinkURLByTitle` already returns a leading slash). NEVER concatenate `normalizeTitle` directly into an absolute URL.
+
+### Empty-slug edge case is intentionally unhandled
+
+- **Symptom**: a hypothetical title made entirely of stripped chars (e.g. `???`) normalizes to an empty string, and `getStaticPaths` then emits `/`, colliding with the root index. Next.js would surface this as a duplicate-path build error.
+- **Why**: no live post hits this case; adding a guard would be dead code today.
+- **Rule**: if `pnpm run build` ever reports duplicate paths or an empty slug, add an explicit guard in `normalizeTitle` (throw or use a fallback slug). Treat that build error as the trigger to revisit this decision — do NOT pre-empt it.
+
+## Conventions
+
+- The denylist `[?#/\\%]` is the **only** character set `normalizeTitle` strips. Adding any other character is a backward-compatibility decision and MUST be preceded by an audit pass against `config/posts.config.ts`.
+- Audit recipe (run before extending the denylist):
+  ```sh
+  node --experimental-strip-types -e "
+    const newNorm = (t) => t.replace(/\s/g, '-').replace(/<NEW_REGEX>/g, '').toLowerCase();
+    const oldNorm = (t) => t.replace(/\s/g, '-').replace(/[?#\/\\\\%]/g, '').toLowerCase();
+    import('./config/posts.config.ts').then(({ default: posts }) => {
+      const diffs = posts.filter(p => oldNorm(p.title) !== newNorm(p.title));
+      console.log(diffs.length === 0 ? 'OK' : diffs);
+    });
+  "
+  ```
+  Any non-empty `diffs` output blocks the change.
+- Absolute post URLs (canonical, OG, share links) MUST go through `PostUtil.buildLinkURLByTitle`. If a second call site for the full pattern `` `${baseURL}${buildLinkURLByTitle(...)}` `` appears, extract a `PostUtil.buildCanonicalURL(post)` helper at that point — not before (one call site is YAGNI).
+- The denylist set MUST stay aligned with the basename-matching invariant in [`sitemap-generation-gotchas.md`](sitemap-generation-gotchas.md). Both sides go through `normalizeTitle`, so any change here propagates to sitemap post matching automatically.
+
+## Rationale
+
+The bug pattern that triggered this document was a title ending in `?`. The instinct fix — switch to a whitelist of "obviously safe" characters — broke 7 live posts whose slugs contained `(`, `)`, `:`, `|`, `+`, or `,`. None of those characters actually break HTTP routing or GitHub Pages file serving; only the 5 in the denylist do. The conservative denylist is the minimum change that fixes the bug while preserving every existing URL.

--- a/.claude/docs/sitemap-generation-gotchas.md
+++ b/.claude/docs/sitemap-generation-gotchas.md
@@ -30,7 +30,7 @@ Read this when: modifying `bin/generate-sitemap.ts`, changing how post URLs are 
 
 - **Symptom**: a post HTML emitted under a subdirectory (e.g. `docs/posts/some-title.html` instead of `docs/some-title.html`) gets `<lastmod>` set to today instead of its `publishedAt`. Search Console then re-crawls the post on every deploy.
 - **Why**: the match key between the filesystem walk and `posts.config.ts` is the normalized post title (`PostUtil.normalizeTitle`). If the lookup key is derived from the full relative path (e.g. `posts/some-title`), it can never equal the normalized title (`some-title`) and the file falls through to the non-post branch.
-- **Rule**: ALWAYS derive the post-match key with `path.basename(htmlFullPath, '.html')` so the match is independent of which directory the static export drops the HTML into. The post URL itself still comes from `PostUtil.buildLinkURLByTitle(post.title)` — the on-disk directory is never used to build `<loc>`, only to enumerate which HTML files exist.
+- **Rule**: ALWAYS derive the post-match key with `path.basename(htmlFullPath, '.html')` so the match is independent of which directory the static export drops the HTML into. The post URL itself still comes from `PostUtil.buildLinkURLByTitle(post.title)` — the on-disk directory is never used to build `<loc>`, only to enumerate which HTML files exist. The basename match relies on `normalizeTitle` producing a filename-safe slug; see [post-slug-normalization-gotchas.md](post-slug-normalization-gotchas.md) for which characters are stripped and why.
 
 ### Strip `index.html` BEFORE `.html` in the non-post branch
 

--- a/pages/[title].tsx
+++ b/pages/[title].tsx
@@ -59,7 +59,7 @@ const PostDetail: NextPage<PostDetailPageProps> = ({ post, content, postsByCateg
       <CommonMeta
         title={TitleUtil.buildPageTitle(META_CONTENTS.POST.TITLE(post.title))}
         description={META_CONTENTS.POST.DESCRIPTION(post.title, post.description, post.category, post.tags)}
-        url={`${blogConfig.baseURL}/${PostUtil.normalizeTitle(post.title)}`}
+        url={`${blogConfig.baseURL}${PostUtil.buildLinkURLByTitle(post.title)}`}
         imageURL={PathUtil.buildImagePath(post.thumbnailName)}
         keywords={[...post.tags, post.title, post.description, post.category]}
       />

--- a/utils/PostUtil.ts
+++ b/utils/PostUtil.ts
@@ -3,7 +3,10 @@ import { Post } from '../config/posts.config'
 
 class PostUtil {
   public static normalizeTitle(title: string) {
-    return title.replace(/\s/g, '-').toLowerCase()
+    return title
+      .replace(/\s/g, '-')
+      .replace(/[?#/\\%]/g, '')
+      .toLowerCase()
   }
 
   public static getMarkdownFilePath(post: Post) {


### PR DESCRIPTION
## 요약
post 제목에 `?`, `#`, `/`, `\`, `%` 등 URL 예약문자가 포함되면 정적 export된 페이지가 404로 떨어지는 버그 수정. `normalizeTitle`에서 해당 문자만 제거하고, canonical URL은 `buildLinkURLByTitle` 경유로 percent-encoding 적용.

## 변경 사항
- `utils/PostUtil.ts`: `normalizeTitle`이 `[?#/\\%]` 문자를 슬러그에서 제거
- `pages/[title].tsx`: canonical URL을 `buildLinkURLByTitle` 기반으로 변경
- `.claude/docs/post-slug-normalization-gotchas.md`: 새 게쳐 문서 (denylist 선정 근거, audit recipe, 빈-슬러그 재검토 트리거)
- `.claude/docs/index.md`: 새 문서 routing
- `.claude/docs/sitemap-generation-gotchas.md`: post-slug 문서로 cross-link

## 관련 이슈
Closes #129

## 테스트 체크리스트
- [ ] `?` 포함 제목으로 새 post 추가 후 `pnpm run docs` 빌드 성공 확인
- [ ] 빌드된 HTML 파일명에 `?`, `#`, `/`, `\`, `%` 없는지 확인
- [ ] 기존 25개 포스트 슬러그가 그대로 유지되는지 audit 스크립트로 확인
- [ ] post 상세 페이지의 `<link rel="canonical">`이 percent-encoding 적용된 URL인지 브라우저 inspector로 확인
- [ ] `sitemap.xml`에 기존 post URL이 정상 포함되는지 확인