### PR TITLE
fix(sitemap): 출력 결정성 확보 및 빈 docs 빌드 가드 추가

### DIFF
--- a/.claude/docs/index.md
+++ b/.claude/docs/index.md
@@ -11,5 +11,5 @@ Read this when: you need to find project knowledge documents written by AI agent
 | How to safely depend on dates, randomness, or other host-runtime values inside a page under `output: 'export'` | [static-export-rendering-gotchas.md](static-export-rendering-gotchas.md) |
 | How Tailwind v4 is set up here, and what classes/tokens MUST NOT be changed | [styling-gotchas.md](styling-gotchas.md) |
 | Why AdSense throws a fatal error at narrow viewports, and why `useIsMobile` threshold is 1100 px | [ads-adsense-rendering-gotchas.md](ads-adsense-rendering-gotchas.md) |
-| How `<loc>` in `sitemap.xml` is encoded, and why post URLs and non-post URLs go through different encoding paths | [sitemap-generation-gotchas.md](sitemap-generation-gotchas.md) |
+| How `<loc>` in `sitemap.xml` is encoded, why post and non-post URLs differ, why sitemap output is sorted, or why an empty `./docs` must fail fast | [sitemap-generation-gotchas.md](sitemap-generation-gotchas.md) |
 | Which characters `PostUtil.normalizeTitle` strips and why, or why a `?`/`#` in a post title 404s | [post-slug-normalization-gotchas.md](post-slug-normalization-gotchas.md) |

--- a/.claude/docs/sitemap-generation-gotchas.md
+++ b/.claude/docs/sitemap-generation-gotchas.md
@@ -44,9 +44,21 @@ Read this when: modifying `bin/generate-sitemap.ts`, changing how post URLs are 
 - **Why**: `encodeURI` only encodes characters that are illegal anywhere in a URI. It preserves all reserved chars (`+`, `&`, `?`, `#`, `:`, etc.) because they are legal in *some* URI position — even when they appear inside a path segment where they shouldn't.
 - **Rule**: ALWAYS use per-segment `encodeURIComponent(decodeURIComponent(segment))` for non-post paths. NEVER apply `encodeURI` to a whole path: it under-encodes reserved chars in segments while doing nothing for already-encoded segments. The decode-then-encode pair handles both directions: `encodeURIComponent('개발환경')` produces the correct percent-encoding, and `decodeURIComponent('%EA%B0%9C…')` then `encodeURIComponent(...)` round-trips to the same encoding without double-escaping.
 
+### Sitemap output MUST be deterministic across builds
+
+- **Symptom**: two consecutive `pnpm run docs` runs against the same source produce sitemaps that differ in `<url>` ordering. CI deploy diffs become noisy and Search Console may treat the sitemap as "changed" on every push.
+- **Why**: `fs.readdirSync` returns entries in filesystem/OS-dependent order. Mapping that list straight to XML fragments preserves whatever order the FS chose, which is not stable across machines (macOS dev vs. Ubuntu CI) or even across builds on the same machine.
+- **Rule**: ALWAYS build `urlEntries` as `{ loc, lastmod }` objects, sort with `(a, b) => a.loc < b.loc ? -1 : a.loc > b.loc ? 1 : 0`, THEN map to XML fragments via `buildUrlSet`. NEVER call `localeCompare` without an explicit locale — it would re-introduce system-locale-dependent ordering. The byte comparator is case-sensitive (ASCII byte ordering): post URLs are lowercase via `normalizeTitle` so they sort cleanly, but non-post HTML segments preserve filesystem case. If a future build emits mixed-case segments that need to interleave with their lowercase counterparts in `<loc>` order, lowercase the comparison key — do NOT change the sort to a locale-aware variant.
+
+### Empty `./docs` MUST fail fast
+
+- **Symptom**: `pnpm run sitemap` produces a `sitemap.xml` containing an empty `<urlset>` and exits 0. The deploy ships an empty sitemap to GitHub Pages; Search Console drops every previously indexed URL.
+- **Why**: `readDirectoryFiles(DOCUMENT_PATH, 'html')` returns `[]` when `./docs` exists but has no HTML files (e.g. `pnpm run sitemap` invoked without a preceding build, or `./docs` cleaned but not repopulated). Without an explicit guard, the empty list flows through `.map`, `.sort`, and `.join('')` to produce a syntactically valid but semantically destructive sitemap.
+- **Rule**: ALWAYS guard `htmlFullPathList.length === 0` with `throw new Error(...)` immediately after `readDirectoryFiles`. The throw MUST happen BEFORE the dynamic `import('../config/posts.config.ts')` so the failure is fast and config loading is skipped. The call site `sitemapGenerator()` MUST attach `.catch((err) => { console.error(err); process.exit(1) })` so the rejected promise surfaces a non-zero exit code instead of being silently swallowed by Node's default unhandled-rejection handler.
+
 ## Conventions
 
-- Sitemap generation MUST run **after** the Next.js static export — `./docs/` must already exist. The `pnpm run sitemap` script will fail if `./docs/` is empty (see [build-pipeline-gotchas.md](build-pipeline-gotchas.md)).
+- Sitemap generation MUST run **after** the Next.js static export — `./docs/` must already exist and contain HTML files. The fail-fast behavior is enforced and described in the "Empty `./docs` MUST fail fast" pitfall above.
 - The XML envelope (`<?xml version="1.0" encoding="UTF-8"?><urlset ...>`) MUST stay sitemap 0.9 namespace — Search Console and Naver both rely on this exact namespace string.
 - `EXCLUDE_FILE_PATTERNS` MUST continue to skip Google / Naver site-verification HTML files; they are not crawlable site content.
 - `<lastmod>` for post URLs MUST use the post's `publishedAt` (not today). Non-post URLs use today's date because they have no first-class authored timestamp.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Always invoke scripts as `pnpm run <script>` — bare `pnpm <script>` collides w
 - `pnpm dev` — Next.js dev server (http://localhost:3000)
 - `pnpm run build` — Next.js production build (writes static export to `./out` because `output: 'export'` is set in `next.config.js`)
 - `pnpm run docs` — full static export pipeline used by CI: cleans, builds, moves `./out` → `./docs`, drops `.nojekyll`, then runs `pnpm run sitemap`. The `./docs` directory is the build output uploaded as the GitHub Pages artifact (see Deployment); it is gitignored and not committed.
-- `pnpm run sitemap` — runs `bin/generate-sitemap.ts` against the just-built `./docs` directory; will fail if `./docs` is empty.
+- `pnpm run sitemap` — runs `bin/generate-sitemap.ts` against the just-built `./docs` directory; fails fast with a non-zero exit if `./docs` is missing or contains zero HTML files. `<url>` entries are sorted lexicographically by `<loc>` so consecutive builds emit byte-identical sitemaps.
 - `pnpm run licenses` — regenerates `public/licenses.json` (consumed by `/licenses` page) using `license-checker-rseidelsohn`.
 - `pnpm run lint` — ESLint CLI (`eslint .`) configured via `eslint.config.mjs` (flat config). Uses `FlatCompat` to bring in `next/core-web-vitals` since `eslint-config-next@15` still ships as legacy eslintrc; `@next/next/no-img-element` is intentionally disabled — native `<img>` is allowed. Build outputs (`.next/`, `out/`, `docs/`, `public/`) are ignored.
 

--- a/bin/generate-sitemap.ts
+++ b/bin/generate-sitemap.ts
@@ -1,6 +1,5 @@
 import fs from 'fs'
 import path from 'path'
-import { exit } from 'process'
 import { Post } from '../config/posts.config'
 import PostUtil from '../utils/PostUtil'
 
@@ -18,10 +17,17 @@ const buildUrlSet = (loc: string, lastModified: string) => {
 
 const sitemapGenerator = async () => {
   const htmlFullPathList = readDirectoryFiles(DOCUMENT_PATH, 'html')
+
+  if (htmlFullPathList.length === 0) {
+    throw new Error(
+      'No HTML files found under ./docs. Run `pnpm run build` (or `pnpm run docs`) before generating the sitemap.'
+    )
+  }
+
   const { posts } = await import(path.join(__dirname, '../config/posts.config.ts'))
   const normalizedPostTiles = new Set(posts.map((post: Post) => `${PostUtil.normalizeTitle(post.title)}`))
 
-  const urlSets = htmlFullPathList.map((htmlFullPath) => {
+  const urlEntries = htmlFullPathList.map((htmlFullPath) => {
     const htmlBaseName = path.basename(htmlFullPath, '.html')
     const isPostingHtml = normalizedPostTiles.has(htmlBaseName)
     const today = new Date()
@@ -31,7 +37,7 @@ const sitemapGenerator = async () => {
       const foundPostConfig: Post | undefined = posts.find((post: Post) => PostUtil.normalizeTitle(post.title) === htmlBaseName)
       if (!foundPostConfig) throw new Error('Failed to find matched posting config')
 
-      return buildUrlSet(PostUtil.buildLinkURLByTitle(foundPostConfig.title), foundPostConfig.publishedAt)
+      return { loc: PostUtil.buildLinkURLByTitle(foundPostConfig.title), lastmod: foundPostConfig.publishedAt }
     } else {
       const relativePath = path.relative(DOCUMENT_PATH, htmlFullPath).split(path.sep).join('/')
       const htmlPath = `/${relativePath}`.replace(/index\.html$/, '').replace(/\.html$/, '')
@@ -39,14 +45,16 @@ const sitemapGenerator = async () => {
         .split('/')
         .map((segment) => encodeURIComponent(decodeURIComponent(segment)))
         .join('/')
-      return buildUrlSet(encodedPath, yyyymmdd)
+      return { loc: encodedPath, lastmod: yyyymmdd }
     }
   })
 
+  urlEntries.sort((a, b) => (a.loc < b.loc ? -1 : a.loc > b.loc ? 1 : 0))
+
+  const urlSets = urlEntries.map(({ loc, lastmod }) => buildUrlSet(loc, lastmod))
   const siteMap = `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urlSets.join('')}</urlset>`
 
   fs.writeFileSync(path.join(DOCUMENT_PATH, 'sitemap.xml'), siteMap, { encoding: 'utf8' })
-  exit(0)
 }
 
 const readDirectoryFiles = (directoryPath: string, ext: string) => {
@@ -72,4 +80,7 @@ const readDirectoryFiles = (directoryPath: string, ext: string) => {
   return matchedFilePaths
 }
 
-sitemapGenerator()
+sitemapGenerator().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## 요약
sitemap 출력의 결정성을 확보하고(loc 기준 사전식 정렬), 빈 `./docs` 케이스를 fail-fast로 차단. 호출부 `.catch`로 비동기 오류가 exit code 1로 노출되도록 보정.

## 변경 사항
- `bin/generate-sitemap.ts`: `urlEntries`를 `{loc, lastmod}` 객체로 빌드 → `loc` 사전식 정렬 → `urlSets` 매핑 순서로 리팩토링; `htmlFullPathList.length === 0` 가드 추가; 호출부에 `.catch((err) => { console.error(err); process.exit(1) })` attach; 미사용 `import { exit } from 'process'` 제거
- `CLAUDE.md`: `pnpm run sitemap` 설명을 실제 동작(missing/empty docs 모두 fail-fast, 정렬된 출력)과 동기화
- `.claude/docs/sitemap-generation-gotchas.md`: "Sitemap output MUST be deterministic across builds"와 "Empty \`./docs\` MUST fail fast" 두 pitfall 추가; case-folding 미래 트리거 조건 명시; 기존 Conventions의 중복 fail-fast 언급을 신규 pitfall로 위임
- `.claude/docs/index.md`: 라우팅 entry에 sort/empty-docs 키워드 포함

## 관련 이슈
Closes #117

## 테스트 체크리스트
- [ ] `pnpm run docs` 두 번 연속 실행 후 `docs/sitemap.xml` byte-identical 확인 (`diff` 0)
- [ ] `rm -rf docs && mkdir docs && pnpm run sitemap` 실행 시 non-zero exit + "No HTML files found under ./docs" 메시지 출력 확인
- [ ] `rm -rf docs && pnpm run sitemap` 실행 시 non-zero exit (missing docs 케이스 회귀 없음) 확인
- [ ] `pnpm run lint` 통과 확인
- [ ] `sitemap.xml` 내 post URL의 `<lastmod>`가 publishedAt 그대로 유지되는지 확인 (정렬이 lastmod에 영향 없는지 검증)