### PR TITLE
fix(sitemap): BASE_URL을 blogConfig/env로 단일화

### DIFF
--- a/.claude/docs/index.md
+++ b/.claude/docs/index.md
@@ -11,5 +11,5 @@ Read this when: you need to find project knowledge documents written by AI agent
 | How to safely depend on dates, randomness, or other host-runtime values inside a page under `output: 'export'` | [static-export-rendering-gotchas.md](static-export-rendering-gotchas.md) |
 | How Tailwind v4 is set up here, and what classes/tokens MUST NOT be changed | [styling-gotchas.md](styling-gotchas.md) |
 | Why AdSense throws a fatal error at narrow viewports, and why `useIsMobile` threshold is 1100 px | [ads-adsense-rendering-gotchas.md](ads-adsense-rendering-gotchas.md) |
-| How `<loc>` in `sitemap.xml` is encoded, why post and non-post URLs differ, why sitemap output is sorted, or why an empty `./docs` must fail fast | [sitemap-generation-gotchas.md](sitemap-generation-gotchas.md) |
+| Where the sitemap base URL comes from, why `ts-node` does not auto-load `.env.*`, how `<loc>` in `sitemap.xml` is encoded, why post and non-post URLs differ, why sitemap output is sorted, or why an empty `./docs` must fail fast | [sitemap-generation-gotchas.md](sitemap-generation-gotchas.md) |
 | Which characters `PostUtil.normalizeTitle` strips and why, or why a `?`/`#` in a post title 404s | [post-slug-normalization-gotchas.md](post-slug-normalization-gotchas.md) |

--- a/.claude/docs/sitemap-generation-gotchas.md
+++ b/.claude/docs/sitemap-generation-gotchas.md
@@ -1,12 +1,24 @@
 # Sitemap Generation Gotchas
 
-Read this when: modifying `bin/generate-sitemap.ts`, changing how post URLs are built (`utils/PostUtil.ts`), or debugging crawler / Search Console errors about malformed `<loc>` values.
+Read this when: modifying `bin/generate-sitemap.ts`, changing how post URLs are built (`utils/PostUtil.ts`), changing where the site base URL comes from (`config/blog.config.ts` / `NEXT_PUBLIC_BASE_URL`), or debugging crawler / Search Console errors about malformed `<loc>` values or wrong-domain sitemaps.
 
 ## Overview
 
-`bin/generate-sitemap.ts` runs after `next build` and walks `./docs/*.html` to emit `docs/sitemap.xml`. Two encoding layers must be applied to every `<loc>`: RFC 3986 percent-encoding (sitemap 0.9 requirement) and XML entity escaping. The post branch and the non-post branch encode differently — mixing them up causes double-encoding or raw-character regressions.
+`bin/generate-sitemap.ts` runs after `next build` and walks `./docs/*.html` to emit `docs/sitemap.xml`. The base URL prefix MUST come from the same source as site canonical URLs (`blogConfig.baseURL` → `NEXT_PUBLIC_BASE_URL`); sitemap is a separate `ts-node` process and does NOT inherit Next's env loading, so the script loads `.env` files via `dotenv` itself. Two encoding layers then apply to every `<loc>`: RFC 3986 percent-encoding (sitemap 0.9 requirement) and XML entity escaping. The post branch and the non-post branch encode differently — mixing them up causes double-encoding or raw-character regressions.
 
 ## Pitfalls
+
+### Sitemap base URL MUST come from `blogConfig` / env — never hardcode
+
+- **Symptom**: domain changes (custom domain swap, staging→prod cutover) update the site's canonical `<link rel="canonical">` and OG URLs via `NEXT_PUBLIC_BASE_URL`, but `sitemap.xml`'s `<loc>` prefix still points to the old domain. Search Console rejects the sitemap for cross-domain mismatch and previously indexed URLs drop off.
+- **Why**: pages render canonical URLs through `blogConfig.baseURL` (which resolves `process.env.NEXT_PUBLIC_BASE_URL`). If sitemap hardcodes a string literal for the same URL, drift is silent until production indexing breaks — there is no compile-time link between the two sources.
+- **Rule**: ALWAYS read the sitemap base URL through `blogConfig.baseURL`. NEVER define a raw domain string literal in `bin/generate-sitemap.ts`. If a future sitemap variant needs a different base URL (e.g. a CDN host), add a field to `blogConfig` and read it from there — do NOT inline.
+
+### `ts-node` does NOT auto-load `.env.*` — sitemap must load it explicitly
+
+- **Symptom**: `pnpm run docs` succeeds but the generated `sitemap.xml` contains `http://localhost:3000` as the `<loc>` prefix in production. Or `pnpm run sitemap` produces a sitemap whose URLs do not match the deployed site.
+- **Why**: `next build` loads `.env.production` internally, but `pnpm run sitemap` invokes `ts-node bin/generate-sitemap.ts` as a separate Node process that does NOT pass through Next's env loader. Without explicit env loading, `blogConfig.baseURL` evaluates to its localhost fallback (`'http://localhost:3000'`), and Search Console will reject the sitemap.
+- **Rule**: The sitemap script MUST call `dotenv` to load `.env.production` (then `.env` as fallback) BEFORE `blogConfig` is imported — `blogConfig` reads `process.env` at module-eval time, so dotenv calls must execute first. Place the `loadEnv()` calls between the `dotenv` import and the `blogConfig` import; this looks unusual versus standard import grouping but is load-order-critical. ALWAYS validate against the raw `process.env.NEXT_PUBLIC_BASE_URL` (with `.trim()`) — NEVER validate against the resolved `blogConfig.baseURL`, because its localhost fallback would silently pass the guard. Throw and `process.exit(1)` when the raw env is missing or whitespace-only, so CI fails before shipping a broken sitemap.
 
 ### Post URLs and non-post URLs need DIFFERENT encoding paths
 
@@ -59,6 +71,7 @@ Read this when: modifying `bin/generate-sitemap.ts`, changing how post URLs are 
 ## Conventions
 
 - Sitemap generation MUST run **after** the Next.js static export — `./docs/` must already exist and contain HTML files. The fail-fast behavior is enforced and described in the "Empty `./docs` MUST fail fast" pitfall above.
+- Sitemap base URL MUST come from `blogConfig.baseURL`; environment loading MUST happen via `dotenv` before `blogConfig` is imported. See the "Sitemap base URL MUST come from `blogConfig` / env" and "`ts-node` does NOT auto-load `.env.*`" pitfalls above.
 - The XML envelope (`<?xml version="1.0" encoding="UTF-8"?><urlset ...>`) MUST stay sitemap 0.9 namespace — Search Console and Naver both rely on this exact namespace string.
 - `EXCLUDE_FILE_PATTERNS` MUST continue to skip Google / Naver site-verification HTML files; they are not crawlable site content.
 - `<lastmod>` for post URLs MUST use the post's `publishedAt` (not today). Non-post URLs use today's date because they have no first-class authored timestamp.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Always invoke scripts as `pnpm run <script>` — bare `pnpm <script>` collides w
 - `pnpm dev` — Next.js dev server (http://localhost:3000)
 - `pnpm run build` — Next.js production build (writes static export to `./out` because `output: 'export'` is set in `next.config.js`)
 - `pnpm run docs` — full static export pipeline used by CI: cleans, builds, moves `./out` → `./docs`, drops `.nojekyll`, then runs `pnpm run sitemap`. The `./docs` directory is the build output uploaded as the GitHub Pages artifact (see Deployment); it is gitignored and not committed.
-- `pnpm run sitemap` — runs `bin/generate-sitemap.ts` against the just-built `./docs` directory; fails fast with a non-zero exit if `./docs` is missing or contains zero HTML files. `<url>` entries are sorted lexicographically by `<loc>` so consecutive builds emit byte-identical sitemaps.
+- `pnpm run sitemap` — runs `bin/generate-sitemap.ts` against the just-built `./docs` directory to emit `docs/sitemap.xml`. Fails fast on missing/whitespace `NEXT_PUBLIC_BASE_URL`, missing `./docs`, or zero HTML files. See [.claude/docs/sitemap-generation-gotchas.md](.claude/docs/sitemap-generation-gotchas.md) for env loading, base URL sourcing, and determinism rules.
 - `pnpm run licenses` — regenerates `public/licenses.json` (consumed by `/licenses` page) using `license-checker-rseidelsohn`.
 - `pnpm run lint` — ESLint CLI (`eslint .`) configured via `eslint.config.mjs` (flat config). Uses `FlatCompat` to bring in `next/core-web-vitals` since `eslint-config-next@15` still ships as legacy eslintrc; `@next/next/no-img-element` is intentionally disabled — native `<img>` is allowed. Build outputs (`.next/`, `out/`, `docs/`, `public/`) are ignored.
 

--- a/bin/generate-sitemap.ts
+++ b/bin/generate-sitemap.ts
@@ -1,9 +1,15 @@
+import { config as loadEnv } from 'dotenv'
 import fs from 'fs'
 import path from 'path'
+
+// dotenv must run before blogConfig is imported — blogConfig reads process.env at module eval.
+loadEnv({ path: path.join(__dirname, '../.env.production') })
+loadEnv({ path: path.join(__dirname, '../.env') })
+
+import blogConfig from '../config/blog.config'
 import { Post } from '../config/posts.config'
 import PostUtil from '../utils/PostUtil'
 
-const BASE_URL = 'https://code-logs.github.io'
 const DOCUMENT_PATH = path.join(__dirname, '../docs')
 const EXCLUDE_FILE_PATTERNS = [/^(google760f3a7b88ebe070|naver07d3a889618f31ffdab8dc562554ed65)/]
 
@@ -11,11 +17,17 @@ const xmlEscape = (value: string) =>
   value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;')
 
 const buildUrlSet = (loc: string, lastModified: string) => {
-  const location = `${BASE_URL.replace(/\/$/, '')}/${loc.replace(/^\//, '')}`
+  const location = `${blogConfig.baseURL.replace(/\/$/, '')}/${loc.replace(/^\//, '')}`
   return `<url><loc>${xmlEscape(location)}</loc><lastmod>${xmlEscape(lastModified)}</lastmod></url>`
 }
 
 const sitemapGenerator = async () => {
+  if (!process.env.NEXT_PUBLIC_BASE_URL?.trim()) {
+    throw new Error(
+      'NEXT_PUBLIC_BASE_URL is not set. Sitemap generation requires the canonical base URL — set it in .env.production or the CI environment.'
+    )
+  }
+
   const htmlFullPathList = readDirectoryFiles(DOCUMENT_PATH, 'html')
 
   if (htmlFullPathList.length === 0) {


### PR DESCRIPTION
## 요약
sitemap의 하드코딩된 `BASE_URL`을 제거하고 `blogConfig.baseURL` (→ `NEXT_PUBLIC_BASE_URL`)에서 도출되도록 단일화. ts-node 환경에서 `.env.*`를 명시 로드하고, base URL 누락 시 fail-fast하여 production sitemap에 localhost가 박히는 사고를 방지합니다.

## 변경 사항
- `bin/generate-sitemap.ts`: `BASE_URL` 상수 제거, `dotenv`로 `.env.production` → `.env` 명시 로드, `blogConfig.baseURL` 사용
- `bin/generate-sitemap.ts`: `process.env.NEXT_PUBLIC_BASE_URL?.trim()` raw-env 검증 가드 추가 (resolved baseURL은 localhost fallback이 우회하므로 raw env 필수)
- `.claude/docs/sitemap-generation-gotchas.md`: 신규 Pitfall 2개 — "base URL MUST come from blogConfig/env", "ts-node does NOT auto-load .env.*"
- `.claude/docs/index.md`: sitemap route entry에 base URL / env loading 키워드 추가
- `CLAUDE.md`: sitemap 명령 설명을 doc 포인터 패턴(P8)으로 정리

## 관련 이슈
Closes #118

## 테스트 체크리스트
- [ ] \`pnpm run docs\` 정상 빌드 → \`docs/sitemap.xml\`의 \`<loc>\` prefix가 \`.env.production\`의 \`https://code-logs.github.io\`와 일치
- [ ] \`env -u NEXT_PUBLIC_BASE_URL pnpm run sitemap\` → \`Error: NEXT_PUBLIC_BASE_URL is not set...\` + exit 1
- [ ] \`NEXT_PUBLIC_BASE_URL="   " pnpm run sitemap\` (whitespace-only) → 동일한 fail-fast 동작
- [ ] 변경 전 main과 sitemap.xml byte-identical (\`diff\`)
- [ ] \`pnpm run lint\` 통과