### PR TITLE
fix(styles): 다크 모드 포스트 본문 가독성 회복

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -245,127 +245,132 @@
     }
   }
 
-  /* Post body typography.
-     Used together with `prose max-w-none` on the post article. `prose`
-     supplies sensible defaults (margins, list indents, link styling, etc.);
-     these rules selectively override prose where the site's prior
-     typography differs. Specificity: `.post-body & h2` resolves to
-     `(0,1,1)`, beating prose's `:where(...)`-scoped `(0,1,0)` selectors. */
-  .post-body {
-    --tw-prose-body: var(--color-theme-font);
-    --tw-prose-headings: var(--color-theme-font);
-    --tw-prose-lead: var(--color-theme);
-    --tw-prose-links: var(--color-theme-anchor);
-    --tw-prose-bold: var(--color-theme-font);
-    --tw-prose-counters: var(--color-theme);
-    --tw-prose-bullets: var(--color-theme-light);
-    --tw-prose-hr: var(--color-theme-invisible);
-    --tw-prose-quotes: var(--color-theme-font);
-    --tw-prose-quote-borders: var(--color-theme-light);
-    --tw-prose-captions: var(--color-theme);
-    --tw-prose-kbd: var(--color-theme-font);
-    --tw-prose-kbd-shadows: rgb(32 33 69 / 10%);
-    --tw-prose-code: var(--color-theme-font);
-    --tw-prose-pre-code: #fff;
-    --tw-prose-pre-bg: var(--color-code-bg);
-    --tw-prose-th-borders: var(--color-theme-light);
-    --tw-prose-td-borders: var(--color-theme-invisible);
+}
 
-    font-size: 0.9rem;
+/* Post body typography.
+   Used together with `prose max-w-none` on the post article. `prose` supplies
+   sensible defaults (margins, list indents, link styling, etc.); these rules
+   selectively override prose where the site's prior typography differs.
 
-    & ins {
-      margin-top: 20px !important;
-      margin-bottom: 20px !important;
-    }
+   Intentionally unlayered. `@tailwindcss/typography` emits `.prose` into
+   `@layer utilities`, and in CSS the layered cascade beats specificity —
+   any layered override (even at higher specificity) loses to utilities, so
+   the prose light-mode `--tw-prose-*` defaults bleed through in dark mode.
+   Unlayered rules sit above every named layer, so this block wins. */
+.prose.post-body {
+  --tw-prose-body: var(--color-theme-font);
+  --tw-prose-headings: var(--color-theme-font);
+  --tw-prose-lead: var(--color-theme);
+  --tw-prose-links: var(--color-theme-anchor);
+  --tw-prose-bold: var(--color-theme-font);
+  --tw-prose-counters: var(--color-theme);
+  --tw-prose-bullets: var(--color-theme-light);
+  --tw-prose-hr: var(--color-theme-invisible);
+  --tw-prose-quotes: var(--color-theme-font);
+  --tw-prose-quote-borders: var(--color-theme-light);
+  --tw-prose-captions: var(--color-theme);
+  --tw-prose-kbd: var(--color-theme-font);
+  --tw-prose-kbd-shadows: rgb(32 33 69 / 10%);
+  --tw-prose-code: var(--color-theme-font);
+  --tw-prose-pre-code: #fff;
+  --tw-prose-pre-bg: var(--color-code-bg);
+  --tw-prose-th-borders: var(--color-theme-light);
+  --tw-prose-td-borders: var(--color-theme-invisible);
 
-    & ul,
-    & ol {
-      padding-left: var(--spacing-wide);
-    }
+  font-size: 0.9rem;
 
-    & ol,
-    & li {
-      margin-top: var(--spacing-narrow);
-    }
+  & ins {
+    margin-top: 20px !important;
+    margin-bottom: 20px !important;
+  }
 
-    & li {
-      list-style: inherit;
-    }
+  & ul,
+  & ol {
+    padding-left: var(--spacing-wide);
+  }
 
-    & h1,
-    & h2,
-    & h3,
-    & h4 {
-      margin-top: 40px;
-      scroll-margin-top: calc(var(--header-height) + 20px);
-    }
+  & ol,
+  & li {
+    margin-top: var(--spacing-narrow);
+  }
 
-    & h1 {
-      font-size: 2rem;
-    }
+  & li {
+    list-style: inherit;
+  }
 
-    & h2 {
-      font-size: 1.5rem;
-    }
+  & h1,
+  & h2,
+  & h3,
+  & h4 {
+    margin-top: 40px;
+    scroll-margin-top: calc(var(--header-height) + 20px);
+  }
 
-    & h2,
-    & h3,
-    & h4 {
-      padding-bottom: var(--spacing-common);
-      border-bottom: 1px solid var(--color-theme-light);
-    }
+  & h1 {
+    font-size: 2rem;
+  }
 
-    & p {
-      line-height: 25px;
-    }
+  & h2 {
+    font-size: 1.5rem;
+  }
 
-    & p > code {
-      background-color: #f7f6f3;
-      padding: 2px 5px;
-      border-radius: 4px;
-      color: #eb5757;
-    }
+  & h2,
+  & h3,
+  & h4 {
+    padding-bottom: var(--spacing-common);
+    border-bottom: 1px solid var(--color-theme-light);
+  }
 
+  & p {
+    line-height: 25px;
+  }
+
+  & p > code {
+    background-color: #f7f6f3;
+    padding: 2px 5px;
+    border-radius: 4px;
+    color: #eb5757;
+  }
+
+  & blockquote {
+    padding: 0.8rem 1rem;
+    margin: 0;
+    border-left: 0.25rem solid var(--color-theme-light);
+    background-color: #f7f6f3;
+  }
+
+  & blockquote > p {
+    margin: 0;
+  }
+
+  & a {
+    font-style: italic;
+    text-decoration: underline;
+  }
+
+  & figure {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: var(--spacing-wide) 0;
+    color: var(--color-theme-font);
+  }
+
+  & table {
+    display: block;
+    overflow-x: auto;
+  }
+
+  @media (max-width: 800px) {
+    font-size: 1rem;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    --tw-prose-kbd-shadows: rgb(255 255 255 / 10%);
+
+    & p > code,
     & blockquote {
-      padding: 0.8rem 1rem;
-      margin: 0;
-      border-left: 0.25rem solid var(--color-theme-light);
-      background-color: #f7f6f3;
-    }
-
-    & blockquote > p {
-      margin: 0;
-    }
-
-    & a {
-      font-style: italic;
-      text-decoration: underline;
-    }
-
-    & figure {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      padding: var(--spacing-wide) 0;
-      color: var(--color-theme-font);
-    }
-
-    & table {
-      display: block;
-      overflow-x: auto;
-    }
-
-    @media (max-width: 800px) {
-      font-size: 1rem;
-    }
-
-    @media (prefers-color-scheme: dark) {
-      --tw-prose-kbd-shadows: rgb(255 255 255 / 10%);
-
-      & p > code,
-      & blockquote {
-        background-color: #444;
-      }
+      background-color: #444;
     }
   }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -245,6 +245,96 @@
     }
   }
 
+  .post-body {
+    & ins {
+      margin-top: 20px !important;
+      margin-bottom: 20px !important;
+    }
+
+    & ul,
+    & ol {
+      padding-left: var(--spacing-wide);
+    }
+
+    & ol,
+    & li {
+      margin-top: var(--spacing-narrow);
+    }
+
+    & li {
+      list-style: inherit;
+    }
+
+    & h1,
+    & h2,
+    & h3,
+    & h4 {
+      margin-top: 40px;
+      scroll-margin-top: calc(var(--header-height) + 20px);
+    }
+
+    & h1 {
+      font-size: 2rem;
+    }
+
+    & h2 {
+      font-size: 1.5rem;
+    }
+
+    & h2,
+    & h3,
+    & h4 {
+      padding-bottom: var(--spacing-common);
+      border-bottom: 1px solid var(--color-theme-light);
+    }
+
+    & p {
+      line-height: 25px;
+    }
+
+    & p > code {
+      background-color: #f7f6f3;
+      padding: 2px 5px;
+      border-radius: 4px;
+      color: #eb5757;
+    }
+
+    & blockquote {
+      padding: 0.8rem 1rem;
+      margin: 0;
+      border-left: 0.25rem solid var(--color-theme-light);
+      background-color: #f7f6f3;
+    }
+
+    & blockquote > p {
+      margin: 0;
+    }
+
+    & a {
+      font-style: italic;
+      text-decoration: underline;
+    }
+
+    & figure {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: var(--spacing-wide) 0;
+      color: var(--color-theme-font);
+    }
+
+    & table {
+      display: block;
+      overflow-x: auto;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      & p > code,
+      & blockquote {
+        background-color: #444;
+      }
+    }
+  }
 }
 
 /* Post body typography.
@@ -279,98 +369,11 @@
 
   font-size: 0.9rem;
 
-  & ins {
-    margin-top: 20px !important;
-    margin-bottom: 20px !important;
-  }
-
-  & ul,
-  & ol {
-    padding-left: var(--spacing-wide);
-  }
-
-  & ol,
-  & li {
-    margin-top: var(--spacing-narrow);
-  }
-
-  & li {
-    list-style: inherit;
-  }
-
-  & h1,
-  & h2,
-  & h3,
-  & h4 {
-    margin-top: 40px;
-    scroll-margin-top: calc(var(--header-height) + 20px);
-  }
-
-  & h1 {
-    font-size: 2rem;
-  }
-
-  & h2 {
-    font-size: 1.5rem;
-  }
-
-  & h2,
-  & h3,
-  & h4 {
-    padding-bottom: var(--spacing-common);
-    border-bottom: 1px solid var(--color-theme-light);
-  }
-
-  & p {
-    line-height: 25px;
-  }
-
-  & p > code {
-    background-color: #f7f6f3;
-    padding: 2px 5px;
-    border-radius: 4px;
-    color: #eb5757;
-  }
-
-  & blockquote {
-    padding: 0.8rem 1rem;
-    margin: 0;
-    border-left: 0.25rem solid var(--color-theme-light);
-    background-color: #f7f6f3;
-  }
-
-  & blockquote > p {
-    margin: 0;
-  }
-
-  & a {
-    font-style: italic;
-    text-decoration: underline;
-  }
-
-  & figure {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: var(--spacing-wide) 0;
-    color: var(--color-theme-font);
-  }
-
-  & table {
-    display: block;
-    overflow-x: auto;
-  }
-
   @media (max-width: 800px) {
     font-size: 1rem;
   }
 
   @media (prefers-color-scheme: dark) {
     --tw-prose-kbd-shadows: rgb(255 255 255 / 10%);
-
-    & p > code,
-    & blockquote {
-      background-color: #444;
-    }
   }
 }


### PR DESCRIPTION
## Summary
- 다크 모드에서 포스트 상세 화면 본문/제목/`<code>`/`<a>`/blockquote가 어두운 색으로 렌더링되어 `#222` 배경 위에서 가독성이 떨어지던 문제 수정
- `@tailwindcss/typography`가 `.prose`의 `--tw-prose-*` 기본값을 `@layer utilities`에 emit하는데, `.post-body` 오버라이드가 `@layer components`에 있어 cascade 레이어 우선순위에 밀려 적용되지 않은 것이 원인. specificity와 무관하게 utilities 레이어가 components 레이어를 항상 이긴다
- 오버라이드 블록을 `@layer components` 밖으로 빼 unlayered 규칙으로 만들고 셀렉터를 `.prose.post-body`로 변경. unlayered 규칙은 모든 명시적 레이어를 이기므로 `--tw-prose-body: var(--color-theme-font)` 등 오버라이드가 정상 적용됨

## Verification

`prefers-color-scheme: dark` 에뮬레이션으로 `getComputedStyle` 실측 비교 (배포본 vs 수정본):

| 요소 | Before (배포) | After (수정) |
|------|---------------|--------------|
| article 본문 | `oklch(0.373 ...)` 어두움 | `#fff` |
| `h2`, `h3` | `oklch(0.21 ...)` 거의 검정 | `#fff` |
| 인라인 `<code>` | 어두움 on `#444` | `#eb5757` on `#444` |
| `<blockquote>` | 어두움 on `#444` | `#fff` on `#444` |
| `<a>` | 어두움 | `#c6c6c6` (theme anchor) |

라이트 모드 회귀 없음 확인 (본문 `#202145` 유지, code 빨강 on `#f7f6f3` 유지).

## Test plan
- [ ] 라이트 모드 OS에서 포스트 상세 페이지 확인 — 기존과 동일하게 다크 텍스트 on 화이트 배경
- [ ] 다크 모드 OS에서 포스트 상세 페이지 확인 — 본문/제목/`<code>`/`<a>`/blockquote가 모두 밝게 표시되어야 함
- [ ] 코드 블록 (`<pre><code>`) 하이라이트가 깨지지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)