### PR TITLE
feat(styles): Zinc + Teal 시맨틱 컬러 토큰 시스템 도입

### DIFF
--- a/.claude/docs/color-tokens-gotchas.md
+++ b/.claude/docs/color-tokens-gotchas.md
@@ -1,0 +1,90 @@
+# Color Tokens Gotchas
+
+Read this when: editing `styles/globals.css` `@theme`/dark `@media` blocks, adding a new color token, applying a color utility (`bg-*`, `text-*`, `border-*`, `ring-*`) to a component, or changing the dark-mode palette.
+
+## Overview
+
+The color system is a two-tier palette layered under semantic aliases: **Zinc 9-step neutrals** + **Teal 5-step accents** as primitives, **semantic tokens** (`--color-bg-page`, `--color-text-body`, `--color-link`, `--color-danger`, …) as the surface components consume. Dark mode flips only neutrals + link semantics via `prefers-color-scheme: dark`; accents stay light-invariant. Manual dark toggle is out of scope (tracked in #148). The Tailwind v4 namespace rule (`--color-*` prefix is mandatory) is documented in [styling-gotchas.md](styling-gotchas.md) — this doc covers the semantic conventions on top of it.
+
+## Pitfalls
+
+### `bg-accent-600` (light Teal-600) on white fails WCAG AA for normal text
+
+- **Symptom:** A small interactive element (active page number, badge) styled `bg-accent-600 text-white` looks fine visually but trips a WCAG AA contrast check at 3.74:1 (< 4.5:1).
+- **Why:** Teal-600 `#0d9488` is borderline for AA when paired with white at normal text size. The 3:1 large-text exemption does not apply to ~12–14 px text.
+- **Rule:** For white-on-accent UI surfaces, ALWAYS use `bg-accent-700` (`#0f766e` → ~5.47:1). Reserve `bg-accent-600` for non-text surfaces (hover backgrounds, decorative fills) where contrast against a text-color foreground is checked separately.
+
+### `--color-danger: #ef4444` (Tailwind red-500) on white fails AA
+
+- **Symptom:** A `bg-danger text-white` badge measures ~3.76:1 against white.
+- **Why:** Red-500 was the issue spec's first draft, but it fails AA with white text at normal size. The current token resolves to `#dc2626` (red-600, ~4.83:1) for that reason.
+- **Rule:** NEVER change `--color-danger` back to `#ef4444`. If a softer red is needed for a non-text fill (e.g., a 5%-opacity warning surface), introduce a new token (`--color-danger-surface`) rather than weakening `--color-danger` itself.
+
+### Light-mode link `--color-link` is `accent-700`, not `accent-600`
+
+- **Symptom:** An ad-hoc `text-accent-600` link in a component looks slightly off-brand and fails AA (~4.0:1 on white).
+- **Why:** `--color-link` is explicitly bound to `accent-700` in light mode for AA compliance. In dark mode it switches to `accent-400` (brighter teal, ~10:1 on Zinc-950).
+- **Rule:** Components MUST use the `text-link` utility (or `--color-link` directly), NEVER `text-accent-600`/`text-accent-700` directly. The light/dark split is handled in `globals.css` — bypassing it duplicates the decision and breaks dark mode.
+
+### Components referencing primitive tokens directly bypass dark mode
+
+- **Symptom:** A component sets `text-neutral-700` and renders unreadable dark-on-dark text in dark mode.
+- **Why:** The semantic tokens (`--color-text-body`, `--color-text-heading`, …) are what get re-pointed in the dark `@media` block. Primitive tokens (`--color-neutral-*`, `--color-accent-*`) are also overridden in dark mode, but bypass the semantic intent — a component that says "I want neutral-700 specifically" gets `#d4d4d8` in dark mode, which is intended for *body text on dark*, not whatever the component meant.
+- **Rule:** Components MUST use only semantic utilities (`text-text-body`, `text-text-muted`, `text-text-heading`, `bg-bg-page`, `bg-bg-subtle`, `border-divider`, `border-border`, `text-link`, `text-danger`, …). The single exception is `--color-code-bg` consumed by `.prose.post-body --tw-prose-pre-bg`. Primitives are palette infrastructure, not application surface.
+
+### `border-border` vs `border-divider` is semantic, not stylistic
+
+- **Symptom:** A new component picks one of `border-border` / `border-divider` based on which name reads better, and the visual weight ends up wrong.
+- **Why:** `--color-border` resolves to `neutral-200` (hairline edge — buttons, input boxes, card outlines). `--color-divider` resolves to `neutral-300` (more visible section separator — header/footer rule, list dividers, `<hr>`). They were briefly identical in an earlier draft; they are intentionally different now.
+- **Rule:** Use `border-divider` for horizontal/vertical separators between logical sections. Use `border-border` for the edge of an interactive surface (button, input, card). When in doubt, divider — that is the project default.
+
+## Conventions
+
+### Token tier ownership
+
+| Tier | Examples | Where it lives | Who reads it |
+|---|---|---|---|
+| Primitive — neutral | `--color-neutral-0` … `--color-neutral-900` | `@theme` (light), dark `@media` override | Only semantic tokens. NEVER components. |
+| Primitive — accent | `--color-accent-50` … `--color-accent-700` | `@theme` only — light-invariant | Only semantic tokens. NEVER components. |
+| Semantic | `--color-bg-page`, `--color-text-body`, `--color-link`, `--color-danger`, … | `@theme` (light), dark `@media` override (link only) | All components, all pages, `@layer base`, `.prose.post-body` |
+
+### Semantic token naming uses the long form
+
+ALWAYS name semantic tokens with the role-doubled prefix even when it reads repetitively: `--color-bg-page`, `--color-text-body`, `--color-bg-subtle`. The resulting utility names are `bg-bg-page`, `text-text-body` — visually redundant but unambiguous about the token's role. Short names (`--color-page`, `--color-body`) were considered and rejected because `bg-page` collides with the mental model of "page = a route file".
+
+### Dark mode flips only what diverges
+
+The dark `@media` block MUST override only:
+- All 8 neutral steps (Zinc 0–900 → Zinc 950→50 inverse).
+- `--color-link` (accent-700 → accent-400) and `--color-link-hover` (accent-600 → accent-500).
+
+Accent primitives (`--color-accent-*`) stay identical in both modes — the Teal palette is light-invariant by design. Semantic tokens that derive from neutrals/accents do not need their own dark override because they re-resolve through the overridden primitives. NEVER duplicate the dark override at the semantic layer; that creates two places to update.
+
+### Forward-looking tokens are defined but unused
+
+The following tokens are intentionally defined for upcoming work even though no current component consumes them. Do NOT prune as YAGNI:
+
+| Token | Reserved for |
+|---|---|
+| `--color-success`, `--color-warning` | Future status surfaces (success banners, warning toasts) |
+| `--color-focus-ring` | Universal `:focus-visible` outline — see #147 (motion/focus tokens) |
+| `--color-link-hover` | Hover state on links — wired in #147 |
+| `--color-bg-surface` | Card/elevated surface — wired in #149 (layout container) and #152 (main page) |
+| `--color-accent-50` | Subtle accent surface (hover backgrounds, info banners) |
+
+If a forward-looking token is still unused after its referenced issue closes, that issue did not complete its acceptance criteria — fix the issue, do not remove the token.
+
+### Hardcoded colors are forbidden outside `@theme` and `highlight.css`
+
+NEVER add a hex literal in a component, page, or `@layer components/base` block. The only sanctioned hardcoded colors are:
+- The primitive scale values inside `@theme` (the palette source of truth).
+- `styles/highlight.css` syntax-highlight tokens (kept outside the Tailwind cascade — see [styling-gotchas.md](styling-gotchas.md) §"`highlight.css` is intentionally outside the Tailwind cascade").
+- `--color-code-bg: #212836` (a brand-specific code background that is neither Zinc nor Teal).
+
+If a new color is needed, add it as a primitive (if it's a palette extension) or as a semantic token (if it expresses an intent). NEVER inline it.
+
+## Rationale
+
+The "신뢰감 있는 미니멀" tone target ruled out the legacy GitHub blue + pure-black approach. Zinc was chosen over Slate/Gray for the neutral scale because its slight warm tint reads less clinical at typography sizes. Teal (Tailwind's stock teal scale) was chosen as the accent because (a) it is distinct from any common framework default, (b) its 400/700 split lands in the AA-passable contrast band against both white and Zinc-950 with no exotic gamma adjustments, and (c) the same hue works in both modes — only luminance shifts. The semantic-over-primitive split exists to make future token swaps (e.g., trying Cyan instead of Teal) a single-file edit.
+
+The one-shot legacy-token cutover (no `--color-theme-*` aliases retained) was deliberate per the issue: aliases lengthen the migration tail and accumulate dead code. The `rg "*-theme-*"` sweep is the safety net; CI lint does not catch a phantom utility class.

--- a/.claude/docs/index.md
+++ b/.claude/docs/index.md
@@ -10,6 +10,7 @@ Read this when: you need to find project knowledge documents written by AI agent
 | Why a lucide icon won't size via `font-size`, or where a brand icon went | [icon-library-gotchas.md](icon-library-gotchas.md) |
 | How to safely depend on dates, randomness, or other host-runtime values inside a page under `output: 'export'` | [static-export-rendering-gotchas.md](static-export-rendering-gotchas.md) |
 | How Tailwind v4 is set up here, and what classes/tokens MUST NOT be changed | [styling-gotchas.md](styling-gotchas.md) |
+| Which color token to use where, why `accent-700` (not `accent-600`) is the light-mode link, or how dark-mode pairing works | [color-tokens-gotchas.md](color-tokens-gotchas.md) |
 | Why AdSense throws a fatal error at narrow viewports, and why `useIsMobile` threshold is 1100 px | [ads-adsense-rendering-gotchas.md](ads-adsense-rendering-gotchas.md) |
 | Where the sitemap base URL comes from, why `ts-node` does not auto-load `.env.*`, how `<loc>` in `sitemap.xml` is encoded, why post and non-post URLs differ, why sitemap output is sorted, why an empty `./docs` must fail fast, or why sitemap throws on duplicate normalized post slugs | [sitemap-generation-gotchas.md](sitemap-generation-gotchas.md) |
 | Which characters `PostUtil.normalizeTitle` strips and why, or why a `?`/`#` in a post title 404s | [post-slug-normalization-gotchas.md](post-slug-normalization-gotchas.md) |

--- a/.claude/docs/styling-gotchas.md
+++ b/.claude/docs/styling-gotchas.md
@@ -59,6 +59,7 @@ The project styles itself with Tailwind CSS v4 in CSS-first mode (no `tailwind.c
 
 ## Related
 
+- [color-tokens-gotchas.md](color-tokens-gotchas.md) — semantic color token conventions layered on top of the `@theme` setup documented here (Zinc/Teal primitives, semantic-only consumption rule, WCAG AA notes).
 - [ads-adsense-rendering-gotchas.md](ads-adsense-rendering-gotchas.md) — pitfalls when the aside cell becomes too narrow for AdSense (ties into the `repeat(3, 1fr)` + fixed-width main grid behavior documented above).
 
 ## Rationale

--- a/components/category-indexer/CategoryIndexer.tsx
+++ b/components/category-indexer/CategoryIndexer.tsx
@@ -21,15 +21,15 @@ const CategoryIndexer = ({ categories }: CategoryIndexerProps) => {
           <li key={idx}>
             <a
               href={`/categories/${encodeURIComponent(category)}/1`}
-              className="flex gap-narrow border-b border-theme-light p-narrow"
+              className="flex gap-narrow border-b border-divider p-narrow"
             >
               {newCategories.includes(category) && (
-                <span className="bg-[rgb(253,69,74)] py-narrow px-narrow rounded-[50px] text-white font-semibold italic text-[0.7rem] my-auto">
+                <span className="bg-danger py-narrow px-narrow rounded-[50px] text-white font-semibold italic text-[0.7rem] my-auto">
                   New
                 </span>
               )}
               <span className="flex-1 my-auto capitalize">{(CATEGORIES as any)[category]}</span>
-              <span className="rounded-[50px] bg-theme text-white w-[25px] h-[25px] grid">
+              <span className="rounded-[50px] bg-bg-subtle text-text-body w-[25px] h-[25px] grid">
                 <span className="m-auto">{postsDatabase.countByCategory(category)}</span>
               </span>
             </a>

--- a/components/content-explorer/ContentExplorer.tsx
+++ b/components/content-explorer/ContentExplorer.tsx
@@ -8,7 +8,7 @@ interface Heading {
 }
 
 const activateClass =
-  '-translate-x-[10px] text-theme-light-blue font-semibold italic underline'
+  '-translate-x-[10px] text-link font-semibold italic underline'
 
 const ContentExplorer = () => {
   const [headings, setHeadings] = useState<Heading[]>([])
@@ -85,7 +85,7 @@ const ContentExplorer = () => {
   })
 
   return (
-    <section className="sticky top-[var(--header-height)] mx-[20px] my-0 py-[20px] text-[0.9rem] z-[2] bg-theme-bg [&>ol]:border-l [&>ol]:border-theme-anchor [&_ol]:ps-[20px] [&_li]:my-[10px] [&_a]:inline-block [&_a]:transition-transform [&_a]:duration-100 [&_a]:ease-in-out [&_a:active]:-translate-x-[10px] [&_a:active]:text-theme-light-blue [&_a:active]:font-semibold [&_a:active]:italic [&_a:active]:underline">
+    <section className="sticky top-[var(--header-height)] mx-[20px] my-0 py-[20px] text-[0.9rem] z-[2] bg-bg-page [&>ol]:border-l [&>ol]:border-link [&_ol]:ps-[20px] [&_li]:my-[10px] [&_a]:inline-block [&_a]:transition-transform [&_a]:duration-100 [&_a]:ease-in-out [&_a:active]:-translate-x-[10px] [&_a:active]:text-link [&_a:active]:font-semibold [&_a:active]:italic [&_a:active]:underline">
       <ol>
         {headings.map((heading) => (
           <li key={heading.element.id}>

--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -5,8 +5,8 @@ export interface FooterProps {
 
 const Footer = (props: FooterProps) => {
   return (
-    <footer className="border-t border-theme-light bg-theme-footer-bg">
-      <p className="text-center text-theme font-thin">
+    <footer className="border-t border-divider bg-bg-page">
+      <p className="text-center text-text-muted font-thin">
         {props.message ? props.message : `ⓒ 2021. ${props.author}  all rights reserved.`}
       </p>
     </footer>

--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -15,8 +15,8 @@ export interface HeaderProps {
 
 const Header = ({ title, menus, socialIcons }: HeaderProps) => {
   return (
-    <header className="header-grid pb-wide border-b border-theme-light bg-theme-header-bg max-tablet:pb-0 max-tablet:[&>nav]:m-auto">
-      <span className="[grid-area:title] font-bold text-[2rem] text-center m-auto text-theme-font max-tablet:text-[1.5rem] max-tablet:text-left max-tablet:my-auto max-tablet:mx-0 max-tablet:p-common">
+    <header className="header-grid pb-wide border-b border-divider bg-bg-page max-tablet:pb-0 max-tablet:[&>nav]:m-auto">
+      <span className="[grid-area:title] font-bold text-[2rem] text-center m-auto text-text-heading max-tablet:text-[1.5rem] max-tablet:text-left max-tablet:my-auto max-tablet:mx-0 max-tablet:p-common">
         {title}
       </span>
 

--- a/components/no-found-posting/NoFoundPosting.tsx
+++ b/components/no-found-posting/NoFoundPosting.tsx
@@ -8,7 +8,7 @@ const NoFoundPosting = ({ condition }: NoFoundPostingProps) => (
   <section>
     <h2 className="text-[1.4rem]">발견된 포팅이 없습니다.</h2>
     <p className="text-[1.2rem]">
-      <strong className="text-theme-error">{`'${decodeURIComponent(condition)}'`}</strong>을 통해 발견된 포스팅이 없습니다.
+      <strong className="text-danger">{`'${decodeURIComponent(condition)}'`}</strong>을 통해 발견된 포스팅이 없습니다.
     </p>
 
     <MainAdsBanner />

--- a/components/paginator/Paginator.tsx
+++ b/components/paginator/Paginator.tsx
@@ -39,8 +39,8 @@ const Paginator = ({ page, lastPage, displayCount = 5, query, baseURL }: Paginat
   }
 
   return (
-    <div className="grid p-wide border-t border-theme-light [&_svg]:m-auto [&_svg]:w-6 [&_svg]:h-6 [&_svg]:text-theme">
-      <ul className="m-auto p-0 inline-flex gap-wide [&_li]:m-auto [&_li]:inline-grid [&_li>a]:inline-grid [&_li>a]:text-theme">
+    <div className="grid p-wide border-t border-divider [&_svg]:m-auto [&_svg]:w-6 [&_svg]:h-6 [&_svg]:text-text-muted">
+      <ul className="m-auto p-0 inline-flex gap-wide [&_li]:m-auto [&_li]:inline-grid [&_li>a]:inline-grid [&_li>a]:text-text-muted">
         {page > 1 && (
           <li>
             <a href={buildURL(page - 1)}>
@@ -62,7 +62,7 @@ const Paginator = ({ page, lastPage, displayCount = 5, query, baseURL }: Paginat
           <li key={pageNum}>
             <a
               href={buildURL(pageNum)}
-              className={page === pageNum ? 'bg-theme-blue py-narrow px-common rounded-[4px] !text-white' : ''}
+              className={page === pageNum ? 'bg-accent-700 py-narrow px-common rounded-[4px] !text-white' : ''}
             >
               {pageNum}
             </a>

--- a/components/post-card/PostCard.tsx
+++ b/components/post-card/PostCard.tsx
@@ -9,27 +9,27 @@ export interface PostCardProps {
 }
 
 const PostCard = ({ titleLevel = 3, post }: PostCardProps) => (
-  <article className="clickable post-card-grid gap-common border-t border-theme-light py-wide">
+  <article className="clickable post-card-grid gap-common border-t border-divider py-wide">
     <a
       href={PostUtil.buildLinkURLByTitle(post.title)}
-      className="[grid-area:title] [&>h1]:text-theme-dark [&>h1]:text-[1.5rem] [&>h1]:my-common [&>h2]:text-theme-dark [&>h2]:text-[1.5rem] [&>h2]:my-common [&>h3]:text-theme-dark [&>h3]:text-[1.5rem] [&>h3]:my-common"
+      className="[grid-area:title] [&>h1]:text-text-heading [&>h1]:text-[1.5rem] [&>h1]:my-common [&>h2]:text-text-heading [&>h2]:text-[1.5rem] [&>h2]:my-common [&>h3]:text-text-heading [&>h3]:text-[1.5rem] [&>h3]:my-common"
     >
       {titleLevel === 1 && <h1>{post.title}</h1>}
       {titleLevel === 2 && <h2>{post.title}</h2>}
       {titleLevel === 3 && <h3>{post.title}</h3>}
     </a>
 
-    <span className="[grid-area:category] text-[0.9rem] font-light capitalize italic text-theme">
+    <span className="[grid-area:category] text-[0.9rem] font-light capitalize italic text-text-muted">
       {(CATEGORIES as any)[post.category]}
     </span>
 
-    <span className="[grid-area:publishedAt] text-right text-[0.9rem] font-light text-theme">
+    <span className="[grid-area:publishedAt] text-right text-[0.9rem] font-light text-text-muted">
       {PostUtil.readablePublishedAt(post)}
     </span>
 
     <a
       href={PostUtil.buildLinkURLByTitle(post.title)}
-      className="[grid-area:description] [&>p]:whitespace-pre-wrap [&>p]:mt-0 [&>p]:leading-wide [&>p]:text-theme"
+      className="[grid-area:description] [&>p]:whitespace-pre-wrap [&>p]:mt-0 [&>p]:leading-wide [&>p]:text-text-body"
     >
       <p>{post.description}</p>
     </a>

--- a/components/search-input/SearchInput.tsx
+++ b/components/search-input/SearchInput.tsx
@@ -5,9 +5,9 @@ export interface SearchInputProps extends Omit<React.HTMLProps<HTMLInputElement>
 const SearchInput = (props: SearchInputProps) => {
   return (
     <label className="inline-flex w-full">
-      <Search className="text-theme-dark m-auto" />
+      <Search className="text-text-heading m-auto" />
       <input
-        className="flex-1 border-none bg-theme-bg outline-none p-narrow text-theme-font"
+        className="flex-1 border-none bg-bg-page outline-none p-narrow text-text-body"
         {...props}
         spellCheck={false}
       />

--- a/components/tag-list/TagList.tsx
+++ b/components/tag-list/TagList.tsx
@@ -10,7 +10,7 @@ export interface TagListProps {
 
 const TagList = (props: TagListProps) => {
   return (
-    <ol className="m-0 p-0 [&_ol]:m-0 [&_ol]:p-0 [&_h2]:text-[1.5rem] [&_h2]:pb-narrow [&_h2]:border-b [&_h2]:border-theme-invisible">
+    <ol className="m-0 p-0 [&_ol]:m-0 [&_ol]:p-0 [&_h2]:text-[1.5rem] [&_h2]:pb-narrow [&_h2]:border-b [&_h2]:border-divider">
       {props.indexGroups.map((indexGroup, idx) => (
         <ol key={idx}>
           {indexGroup

--- a/components/tag-navigator/TagNavigator.tsx
+++ b/components/tag-navigator/TagNavigator.tsx
@@ -6,7 +6,7 @@ export interface TagNavigatorProps {
 const TagNavigator = (props: TagNavigatorProps) => {
   const indexesSet = new Set(props.activatedIndexes)
   return (
-    <div className="p-wide [&>ol]:m-0 [&>ol]:p-0 [&>ol_li]:inline-block [&>ol_li]:m-narrow [&>ol_li]:p-0 [&>ol_a]:text-theme-light [&>ol_a]:font-extralight">
+    <div className="p-wide [&>ol]:m-0 [&>ol]:p-0 [&>ol_li]:inline-block [&>ol_li]:m-narrow [&>ol_li]:p-0 [&>ol_a]:text-text-muted [&>ol_a]:font-extralight">
       {props.indexGroups.map((indexes, keyIdx) => {
         return (
           <ol key={keyIdx}>
@@ -14,7 +14,7 @@ const TagNavigator = (props: TagNavigatorProps) => {
               <li key={index}>
                 <a
                   href={`#${index}`}
-                  className={indexesSet.has(index) ? '!text-theme-dark !font-medium' : ''}
+                  className={indexesSet.has(index) ? '!text-text-heading !font-medium' : ''}
                 >
                   {index}
                 </a>

--- a/components/tag/Tag.tsx
+++ b/components/tag/Tag.tsx
@@ -5,7 +5,7 @@ export interface TagProps {
 
 const Tag = (props: TagProps) => (
   <a href={`/posts/1?query=${encodeURIComponent(props.tag)}`}>
-    <span className="clickable block p-2 bg-theme-tag-bg !text-white rounded-[20px] min-w-[40px] text-center cursor-pointer before:content-['#']">
+    <span className="clickable block p-2 bg-bg-subtle text-text-body ring-1 ring-border rounded-[20px] min-w-[40px] text-center cursor-pointer before:content-['#']">
       {props.tag} {props.count && props.count}
     </span>
   </a>

--- a/components/title-with-count/TitleWithCount.tsx
+++ b/components/title-with-count/TitleWithCount.tsx
@@ -7,7 +7,7 @@ export interface TitleWithCountProps {
 const TitleWithCount = (props: TitleWithCountProps) => {
   const innerFragment = (
     <>
-      {props.title} <span className="text-theme font-medium">({props.count})</span>
+      {props.title} <span className="text-text-muted font-medium">({props.count})</span>
     </>
   )
 

--- a/pages/[title].tsx
+++ b/pages/[title].tsx
@@ -45,7 +45,7 @@ export async function getStaticProps(context: { params: { title: string } }) {
 }
 
 const sectionHeadingClass =
-  '[&>h2]:mt-10 [&>h2]:mb-0 [&>h2]:text-[1.5rem] [&>h2]:pb-common [&>h2]:border-b [&>h2]:border-theme-light'
+  '[&>h2]:mt-10 [&>h2]:mb-0 [&>h2]:text-[1.5rem] [&>h2]:pb-common [&>h2]:border-b [&>h2]:border-divider'
 
 const PostDetail: NextPage<PostDetailPageProps> = ({ post, content, postsByCategory }: PostDetailPageProps) => {
   const containerRef = useRef<HTMLElement>(null)
@@ -65,7 +65,7 @@ const PostDetail: NextPage<PostDetailPageProps> = ({ post, content, postsByCateg
       />
 
       <article className="prose max-w-none post-body" ref={containerRef}>
-        <p className="text-[0.9rem] text-theme m-0 text-right">
+        <p className="text-[0.9rem] text-text-muted m-0 text-right">
           <span>{PostUtil.readablePublishedAt(post)}</span>
         </p>
         <section className="relative m-0 [&_img]:object-cover [&_img]:w-full [&_img]:h-[315px] max-tablet:[&_img]:!object-contain max-tablet:[&_img]:h-auto">
@@ -76,7 +76,7 @@ const PostDetail: NextPage<PostDetailPageProps> = ({ post, content, postsByCateg
 
         <section>
           <h1>{post.title}</h1>
-          <p className="italic text-theme text-[1.5rem] whitespace-pre-wrap leading-[2rem]">{post.description}</p>
+          <p className="italic text-text-muted text-[1.5rem] whitespace-pre-wrap leading-[2rem]">{post.description}</p>
         </section>
 
         <section id="content" dangerouslySetInnerHTML={{ __html: content }}></section>

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -29,7 +29,7 @@ const About = ({ careerYears }: AboutProps) => {
         imageURL={'/icons/icon-512x512.png'}
       />
 
-      <article className="[&_section]:mb-8 [&_p]:ml-wide [&_p]:text-theme [&_p]:italic">
+      <article className="[&_section]:mb-8 [&_p]:ml-wide [&_p]:text-text-body [&_p]:italic">
         <h1>About</h1>
 
         <RaiseSection timeout={standardTimeout}>

--- a/pages/licenses/index.tsx
+++ b/pages/licenses/index.tsx
@@ -13,7 +13,7 @@ const Licenses = () => {
         {Object.keys(licenses).map((depName) => {
           return (
             <details
-              className="text-theme [&_summary]:py-common [&_summary]:px-0 [&_a]:text-theme-light-blue"
+              className="text-text-muted [&_summary]:py-common [&_summary]:px-0 [&_a]:text-link"
               key={depName}
             >
               <summary>{depName}</summary>

--- a/pages/posts/[page].tsx
+++ b/pages/posts/[page].tsx
@@ -92,7 +92,7 @@ const Posts: NextPage<PostsProps> = (props) => {
           keywords={posts.map((post) => [...post.tags, post.title, post.description]).flat()}
         />
 
-        <span className="text-theme text-[0.8rem] float-right mt-wide">{query ? `Found ${posts.length}` : `Total ${totalCount}`}</span>
+        <span className="text-text-muted text-[0.8rem] float-right mt-wide">{query ? `Found ${posts.length}` : `Total ${totalCount}`}</span>
         <h1>Posts </h1>
       </>
     ),

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -10,41 +10,74 @@
 
   --leading-wide: var(--spacing-wide);
 
-  --color-theme-bg: #fff;
-  --color-theme-header-bg: #fff;
-  --color-theme-footer-bg: #fff;
-  --color-theme-dark: #444;
-  --color-theme: #666;
-  --color-theme-light: #ccc;
-  --color-theme-invisible: #eee;
-  --color-theme-light-blue: #3699f9;
-  --color-theme-blue: #0366d6;
-  --color-theme-tag-bg: #000;
-  --color-theme-font: #202145;
-  --color-theme-error: #e26674;
-  --color-theme-anchor: var(--color-theme-blue);
+  /* ── Neutral scale (Zinc light-mode) ─────────────────────────────── */
+  --color-neutral-0:   #ffffff;
+  --color-neutral-50:  #fafafa;
+  --color-neutral-100: #f4f4f5;
+  --color-neutral-200: #e4e4e7;
+  --color-neutral-300: #d4d4d8;
+  --color-neutral-500: #71717a;
+  --color-neutral-700: #3f3f46;
+  --color-neutral-900: #18181b;
+
+  /* ── Accent scale (Teal) ──────────────────────────────────────────── */
+  --color-accent-50:  #f0fdfa;
+  --color-accent-400: #2dd4bf;
+  --color-accent-500: #14b8a6;
+  --color-accent-600: #0d9488;
+  --color-accent-700: #0f766e;
+
+  /* ── Semantic tokens ──────────────────────────────────────────────── */
+  --color-bg-page:    var(--color-neutral-0);
+  --color-bg-surface: var(--color-neutral-50);
+  --color-bg-subtle:  var(--color-neutral-100);
+  --color-border:     var(--color-neutral-200);
+  --color-divider:    var(--color-neutral-300);
+
+  --color-text-muted:   var(--color-neutral-500);
+  --color-text-body:    var(--color-neutral-700);
+  --color-text-heading: var(--color-neutral-900);
+
+  /* Light-mode link uses accent-700 for WCAG AA (≥4.5:1 on white) */
+  --color-link:       var(--color-accent-700);
+  --color-link-hover: var(--color-accent-600);
+
+  --color-focus-ring: color-mix(in oklab, var(--color-accent-500) 35%, transparent);
+
+  --color-success: #10b981;
+  --color-warning: #f59e0b;
+  /* red-600 (not red-500): white text on this background passes WCAG AA */
+  --color-danger:  #dc2626;
+
+  /* Kept: referenced by .prose.post-body --tw-prose-pre-bg */
   --color-code-bg: #212836;
 }
 
 @layer base {
   :root {
-    --common-shadow: 2px 2px 2px var(--color-theme);
+    /* Consumed by styles/highlight.css (pre code box-shadow) */
+    --common-shadow: 2px 2px 2px var(--color-border);
     --header-height: 140px;
     --footer-height: 50px;
   }
 
+  /* Dark mode: only neutrals and link semantics flip. Accent tokens stay
+     identical in both modes — the Teal palette is light-invariant. */
   @media (prefers-color-scheme: dark) {
     :root {
-      --color-theme-bg: #222;
-      --color-theme-header-bg: #222;
-      --color-theme-footer-bg: #222;
-      --color-theme-dark: #eee;
-      --color-theme: #ccc;
-      --color-theme-light: #666;
-      --color-theme-invisible: #444;
-      --color-theme-tag-bg: #444;
-      --color-theme-font: #fff;
-      --color-theme-anchor: #c6c6c6;
+      /* Neutral scale inverted to Zinc 950→50 */
+      --color-neutral-0:   #09090b;
+      --color-neutral-50:  #18181b;
+      --color-neutral-100: #27272a;
+      --color-neutral-200: #3f3f46;
+      --color-neutral-300: #52525b;
+      --color-neutral-500: #a1a1aa;
+      --color-neutral-700: #d4d4d8;
+      --color-neutral-900: #fafafa;
+
+      /* Dark-mode links use brighter teal */
+      --color-link:       var(--color-accent-400);
+      --color-link-hover: var(--color-accent-500);
     }
   }
 
@@ -55,7 +88,7 @@
     font-family:
       -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu,
       Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
-    background-color: var(--color-theme-bg);
+    background-color: var(--color-bg-page);
     scroll-margin-top: var(--header-height);
     scroll-behavior: smooth;
   }
@@ -73,7 +106,7 @@
   }
 
   a {
-    color: var(--color-theme-anchor);
+    color: var(--color-link);
     text-decoration: none;
     -webkit-tap-highlight-color: transparent;
   }
@@ -127,7 +160,7 @@
   ul,
   li,
   table {
-    color: var(--color-theme-font);
+    color: var(--color-text-body);
   }
 
   h1,
@@ -285,7 +318,7 @@
     & h3,
     & h4 {
       padding-bottom: var(--spacing-common);
-      border-bottom: 1px solid var(--color-theme-light);
+      border-bottom: 1px solid var(--color-divider);
     }
 
     & p {
@@ -293,17 +326,17 @@
     }
 
     & p > code {
-      background-color: #f7f6f3;
+      background-color: var(--color-bg-subtle);
       padding: 2px 5px;
       border-radius: 4px;
-      color: #eb5757;
+      color: var(--color-danger);
     }
 
     & blockquote {
       padding: 0.8rem 1rem;
       margin: 0;
-      border-left: 0.25rem solid var(--color-theme-light);
-      background-color: #f7f6f3;
+      border-left: 0.25rem solid var(--color-divider);
+      background-color: var(--color-bg-subtle);
     }
 
     & blockquote > p {
@@ -320,19 +353,12 @@
       flex-direction: column;
       align-items: center;
       padding: var(--spacing-wide) 0;
-      color: var(--color-theme-font);
+      color: var(--color-text-body);
     }
 
     & table {
       display: block;
       overflow-x: auto;
-    }
-
-    @media (prefers-color-scheme: dark) {
-      & p > code,
-      & blockquote {
-        background-color: #444;
-      }
     }
   }
 }
@@ -348,32 +374,28 @@
    the prose light-mode `--tw-prose-*` defaults bleed through in dark mode.
    Unlayered rules sit above every named layer, so this block wins. */
 .prose.post-body {
-  --tw-prose-body: var(--color-theme-font);
-  --tw-prose-headings: var(--color-theme-font);
-  --tw-prose-lead: var(--color-theme);
-  --tw-prose-links: var(--color-theme-anchor);
-  --tw-prose-bold: var(--color-theme-font);
-  --tw-prose-counters: var(--color-theme);
-  --tw-prose-bullets: var(--color-theme-light);
-  --tw-prose-hr: var(--color-theme-invisible);
-  --tw-prose-quotes: var(--color-theme-font);
-  --tw-prose-quote-borders: var(--color-theme-light);
-  --tw-prose-captions: var(--color-theme);
-  --tw-prose-kbd: var(--color-theme-font);
-  --tw-prose-kbd-shadows: rgb(32 33 69 / 10%);
-  --tw-prose-code: var(--color-theme-font);
+  --tw-prose-body: var(--color-text-body);
+  --tw-prose-headings: var(--color-text-heading);
+  --tw-prose-lead: var(--color-text-muted);
+  --tw-prose-links: var(--color-link);
+  --tw-prose-bold: var(--color-text-body);
+  --tw-prose-counters: var(--color-text-muted);
+  --tw-prose-bullets: var(--color-divider);
+  --tw-prose-hr: var(--color-border);
+  --tw-prose-quotes: var(--color-text-body);
+  --tw-prose-quote-borders: var(--color-divider);
+  --tw-prose-captions: var(--color-text-muted);
+  --tw-prose-kbd: var(--color-text-heading);
+  --tw-prose-kbd-shadows: color-mix(in oklab, var(--color-text-heading) 10%, transparent);
+  --tw-prose-code: var(--color-text-body);
   --tw-prose-pre-code: #fff;
   --tw-prose-pre-bg: var(--color-code-bg);
-  --tw-prose-th-borders: var(--color-theme-light);
-  --tw-prose-td-borders: var(--color-theme-invisible);
+  --tw-prose-th-borders: var(--color-border);
+  --tw-prose-td-borders: var(--color-divider);
 
   font-size: 0.9rem;
 
   @media (max-width: 800px) {
     font-size: 1rem;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    --tw-prose-kbd-shadows: rgb(255 255 255 / 10%);
   }
 }


### PR DESCRIPTION
## 요약
명도 기반 레거시 `--color-theme-*` 토큰을 Zinc 9단계 뉴트럴 + Teal 5단계 액센트 primitive와 의미 단위 semantic 토큰으로 전면 교체. 컴포넌트는 semantic 유틸만 참조하도록 일괄 마이그레이션 (호환 alias 없는 one-shot cutover).

## 변경 사항
- `styles/globals.css`의 `@theme` 블록 전면 재정의: neutral 9단계 + accent 5단계 + semantic 토큰
- 다크모드 페어링: neutral만 invert, accent는 light-invariant (`prefers-color-scheme: dark`)
- WCAG AA 보정: `--color-link` = accent-700 (~5.47:1), `--color-danger` = `#dc2626` (~4.83:1)
- `--color-border` (neutral-200, hairline) ↔ `--color-divider` (neutral-300, 섹션 구분) 의미 분리
- 14 components + 4 pages를 semantic 유틸(`bg-bg-page`, `text-text-body`, `text-link`, `border-divider`, `text-danger` 등)로 마이그레이션
- `.post-body` 인라인 코드 색을 `--color-danger`로 통일, `--common-shadow`를 `--color-border` 기반으로 재타게팅, `--tw-prose-kbd-shadows` 시맨틱화
- forward-looking 토큰(`success`, `warning`, `focus-ring`, `link-hover`, `bg-surface`, `accent-50`)은 후속 이슈(#145~#148)용으로 정의
- 의사결정 문서 `.claude/docs/color-tokens-gotchas.md` 추가 + `index.md` / `styling-gotchas.md` cross-link 갱신

## 관련 이슈
Closes #144

## 테스트 체크리스트
- [ ] `pnpm run lint` 통과 (구현 시점 확인됨)
- [ ] `pnpm run build` 통과 (49 페이지 정적 생성 확인됨)
- [ ] `rg "color-theme-|bg-theme|text-theme|border-theme"` 0건 (확인됨)
- [ ] `pnpm dev` 라이트 모드 시각 회귀 확인: 홈/카테고리/포스트 상세/태그/Licenses/Search
- [ ] `pnpm dev` 다크 모드 시각 회귀 확인 (페이지 BG `#222` → `#09090b`)
- [ ] WCAG AA: 본문 텍스트, 링크, Paginator 활성, "New" 배지 — 라이트·다크 모두 ≥ 4.5:1
- [ ] Tag 컴포넌트 — 흰 배지 → subtle 배경 + ring으로 시각 전환 확인
- [ ] CategoryIndexer "New" 배지 — 더 진한 빨강(`#dc2626`)으로 렌더 확인