### PR TITLE
feat(styles): 스페이싱 스케일 + 라운드 토큰 정리

### DIFF
--- a/.claude/docs/index.md
+++ b/.claude/docs/index.md
@@ -10,6 +10,7 @@ Read this when: you need to find project knowledge documents written by AI agent
 | Why a lucide icon won't size via `font-size`, or where a brand icon went | [icon-library-gotchas.md](icon-library-gotchas.md) |
 | How to safely depend on dates, randomness, or other host-runtime values inside a page under `output: 'export'` | [static-export-rendering-gotchas.md](static-export-rendering-gotchas.md) |
 | How Tailwind v4 is set up here, and what classes/tokens MUST NOT be changed | [styling-gotchas.md](styling-gotchas.md) |
+| Why spacing/radius tokens are px not rem, why they are named `--spacing-*` (not `--space-*`), or why an untouched `rounded-md` element changed radius | [styling-gotchas.md](styling-gotchas.md) |
 | Which color token to use where, why `accent-700` (not `accent-600`) is the light-mode link, or how dark-mode pairing works | [color-tokens-gotchas.md](color-tokens-gotchas.md) |
 | How the self-hosted fonts load, why `--text-*`/`--leading-*` tokens override Tailwind built-ins, why fonts inject from `_app.tsx` not `_document.tsx`, or why post-body headings differ from base `h1~h4` | [typography-system-gotchas.md](typography-system-gotchas.md) |
 | Why AdSense throws a fatal error at narrow viewports, and why `useIsMobile` threshold is 1100 px | [ads-adsense-rendering-gotchas.md](ads-adsense-rendering-gotchas.md) |

--- a/.claude/docs/styling-gotchas.md
+++ b/.claude/docs/styling-gotchas.md
@@ -48,7 +48,19 @@ The project styles itself with Tailwind CSS v4 in CSS-first mode (no `tailwind.c
 
 - **Symptom:** A custom token defined in `@theme` doesn't generate the expected utility.
 - **Why:** Tailwind v4 only auto-generates utilities for tokens that match a registered namespace prefix (`--color-*` → `bg-*`/`text-*`/`border-*`, `--spacing-*` → `m-*`/`p-*`/`gap-*`, `--leading-*` → `leading-*`, `--breakpoint-*` → screen variants, etc.).
-- **Rule:** When adding a token, ALWAYS use the namespace prefix that matches the utility family you want. To get `leading-wide`, the token MUST be named `--leading-wide`, not `--line-height-wide` or `--wide-leading`.
+- **Rule:** When adding a token, ALWAYS use the namespace prefix that matches the utility family you want. To get `leading-wide`, the token MUST be named `--leading-wide`, not `--line-height-wide` or `--wide-leading`. The spacing scale (issue #146) is named `--spacing-1`…`--spacing-24` (NOT `--space-*`) precisely so Tailwind auto-generates `p-1`/`m-1`/`gap-1`/`py-*`/`mt-*`. The semantic aliases (`--spacing-card-inner`, `--spacing-section-gap`, …) share the same prefix so `p-card-inner` etc. would also generate — though components currently consume the numeric steps directly.
+
+### Spacing and radius scale tokens are px-based, not rem
+
+- **Symptom:** Mobile spacing renders smaller than intended, or a margin/padding that looked right on desktop shrinks at ≤768 px.
+- **Why:** `@layer base` sets `@media (max-width: 768px) { :root { font-size: 12px } }`. Tailwind's *default* spacing is rem-based (`--spacing: 0.25rem`), so any rem-based step shrinks to ~75% in that range. The legacy `narrow/common/wide` tokens were px and stayed fixed; issue #146 preserved that by defining `--spacing-1`…`--spacing-24` and `--radius-*` in **px**.
+- **Rule:** Keep the `--spacing-*` and `--radius-*` scale tokens in px. Switching them to rem silently regresses mobile spacing. Note that integer steps you did NOT explicitly define (e.g. `p-7`, `p-9`) still fall back to Tailwind's rem-based `calc(var(--spacing) * n)` — avoid mixing those with the px scale where the difference matters.
+
+### Redefining `--radius-*` / `--spacing-*` in `@theme` overrides Tailwind defaults globally
+
+- **Symptom:** An element you never touched (e.g. the PostCard thumbnail's `rounded-md`) suddenly renders with a different radius/spacing after a token change.
+- **Why:** `@theme` token values override Tailwind's built-in scale. Defining `--radius-md: 10px` / `--radius-sm: 6px` (issue #146) replaces the defaults (`md`=6px, `sm`=4px), so EVERY existing `rounded-md`/`rounded-sm` consumer — even ones not in your diff — re-renders at the new value. Same applies to `--spacing-*`.
+- **Rule:** When choosing scale-token values, account for the blast radius across all existing standard-class consumers, not just the lines you edit. To restyle only some elements, use an arbitrary value or a distinct token instead of redefining the shared scale token.
 
 ## Conventions
 
@@ -56,6 +68,7 @@ The project styles itself with Tailwind CSS v4 in CSS-first mode (no `tailwind.c
 - New design tokens MUST be added to the `@theme` block in `globals.css`. Dark-mode overrides live in the same file's `@media (prefers-color-scheme: dark)` block — the codebase uses media-query dark mode, not a class strategy.
 - `normalize.css` MUST NOT be reintroduced. If a preflight reset bites a new component (lists, headings, form controls), restore the affected user-agent default in `globals.css` `@layer base` and document it here.
 - The post-body article element MUST carry `prose max-w-none post-body` together (in that order is fine). `prose` provides the typography baseline; `.post-body` selectively overrides.
+- Spacing and radius design tokens — the px-based `--spacing-1`…`--spacing-24` scale, its semantic aliases (`--spacing-card-inner`, `--spacing-card-gap`, `--spacing-section-inner`, `--spacing-section-gap`, `--spacing-page-x`, `--spacing-page-x-desktop`, `--spacing-page-y`), and the `--radius-sm`…`--radius-full` scale — live in `@theme` (issue #146). Components express spacing/radius via the generated utilities (`p-5`, `gap-3`, `rounded-full`); NEVER reintroduce arbitrary `rounded-[Npx]` or one-off margin/padding literals when a scale step fits.
 
 ## Related
 

--- a/components/ads-banner/AsideAdsBanner.tsx
+++ b/components/ads-banner/AsideAdsBanner.tsx
@@ -2,7 +2,7 @@ import blogConfig from '../../config/blog.config'
 import GoogleAdsenseBanner from '../google-adsense/GoogleAdsenseBanner'
 
 const AsideAdsBanner = () => (
-  <section className="flex flex-col p-wide gap-wide max-w-[200px] mx-auto">
+  <section className="flex flex-col p-5 gap-5 max-w-[200px] mx-auto">
     <GoogleAdsenseBanner adClient={blogConfig.googleAdsense.adClient} adSlot={blogConfig.googleAdsense.asideBannerAdSlot} />
     <GoogleAdsenseBanner adClient={blogConfig.googleAdsense.adClient} adSlot={blogConfig.googleAdsense.asideBannerAdSlot} />
     <GoogleAdsenseBanner adClient={blogConfig.googleAdsense.adClient} adSlot={blogConfig.googleAdsense.asideBannerAdSlot} />

--- a/components/ads-banner/MainAdsBanner.tsx
+++ b/components/ads-banner/MainAdsBanner.tsx
@@ -2,7 +2,7 @@ import blogConfig from '../../config/blog.config'
 import GoogleAdsenseBanner from '../google-adsense/GoogleAdsenseBanner'
 
 const MainAdsBanner = () => (
-  <section className="py-wide">
+  <section className="py-5">
     <GoogleAdsenseBanner adClient={blogConfig.googleAdsense.adClient} adSlot={blogConfig.googleAdsense.mainBannerAdSlot} />
     {/* <KakaoAdfitBanner adfitUnitID={blogConfig.kakaoAdfitUnitIDs.mainBannerID} position="main" /> */}
   </section>

--- a/components/carousel-banner/index.tsx
+++ b/components/carousel-banner/index.tsx
@@ -12,7 +12,7 @@ export interface CarouselBannerProps {
 
 export default function CarouselBanner({ banners }: CarouselBannerProps) {
   return (
-    <div className="max-w-[400px] mt-wide mx-auto">
+    <div className="max-w-[400px] mt-5 mx-auto">
       {banners.map(({ title, bannerSrc, link }) => (
         <a
           key={link}

--- a/components/category-indexer/CategoryIndexer.tsx
+++ b/components/category-indexer/CategoryIndexer.tsx
@@ -21,15 +21,15 @@ const CategoryIndexer = ({ categories }: CategoryIndexerProps) => {
           <li key={idx}>
             <a
               href={`/categories/${encodeURIComponent(category)}/1`}
-              className="flex gap-narrow border-b border-divider p-narrow"
+              className="flex gap-1 border-b border-divider p-1"
             >
               {newCategories.includes(category) && (
-                <span className="bg-danger py-narrow px-narrow rounded-[50px] text-white font-semibold italic text-[0.7rem] my-auto">
+                <span className="bg-danger py-1 px-1 rounded-full text-white font-semibold italic text-[0.7rem] my-auto">
                   New
                 </span>
               )}
               <span className="flex-1 my-auto capitalize">{(CATEGORIES as any)[category]}</span>
-              <span className="rounded-[50px] bg-bg-subtle text-text-body w-[25px] h-[25px] grid">
+              <span className="rounded-full bg-bg-subtle text-text-body w-[25px] h-[25px] grid">
                 <span className="m-auto">{postsDatabase.countByCategory(category)}</span>
               </span>
             </a>

--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -15,12 +15,12 @@ export interface HeaderProps {
 
 const Header = ({ title, menus, socialIcons }: HeaderProps) => {
   return (
-    <header className="header-grid pb-wide border-b border-divider bg-bg-page max-tablet:pb-0 max-tablet:[&>nav]:m-auto">
-      <span className="[grid-area:title] font-bold text-3xl text-center m-auto text-text-heading max-tablet:text-2xl max-tablet:text-left max-tablet:my-auto max-tablet:mx-0 max-tablet:p-common">
+    <header className="header-grid pb-5 border-b border-divider bg-bg-page max-tablet:pb-0 max-tablet:[&>nav]:m-auto">
+      <span className="[grid-area:title] font-bold text-3xl text-center m-auto text-text-heading max-tablet:text-2xl max-tablet:text-left max-tablet:my-auto max-tablet:mx-0 max-tablet:p-3">
         {title}
       </span>
 
-      <ul className="[grid-area:socialIcons] p-wide flex gap-common m-auto [&_li]:my-auto [&_svg]:w-6 [&_svg]:h-6 max-tablet:p-common">
+      <ul className="[grid-area:socialIcons] p-5 flex gap-3 m-auto [&_li]:my-auto [&_svg]:w-6 [&_svg]:h-6 max-tablet:p-3">
         {socialIcons.map((socialIcon, idx) => (
           <li key={idx}>
             <a href={socialIcon.href} target="_blank" rel="noreferrer" aria-label={socialIcon.label}>

--- a/components/nav-bar/NavBar.tsx
+++ b/components/nav-bar/NavBar.tsx
@@ -16,7 +16,7 @@ const NavBar = (props: NavBarProps) => {
 
   return (
     <nav className="[grid-area:navBar] text-center">
-      <ul className="inline-flex gap-wide m-auto p-0 font-medium">
+      <ul className="inline-flex gap-5 m-auto p-0 font-medium">
         {menus.map(({ display, route }, idx) => (
           <li className="clickable" key={idx}>
             <MarkedAnchor href={route} display={display} matched={router.pathname.split('/')[1] === route.split('/')[1]} />

--- a/components/paginator/Paginator.tsx
+++ b/components/paginator/Paginator.tsx
@@ -39,8 +39,8 @@ const Paginator = ({ page, lastPage, displayCount = 5, query, baseURL }: Paginat
   }
 
   return (
-    <div className="grid p-wide border-t border-divider [&_svg]:m-auto [&_svg]:w-6 [&_svg]:h-6 [&_svg]:text-text-muted">
-      <ul className="m-auto p-0 inline-flex gap-wide [&_li]:m-auto [&_li]:inline-grid [&_li>a]:inline-grid [&_li>a]:text-text-muted">
+    <div className="grid p-5 border-t border-divider [&_svg]:m-auto [&_svg]:w-6 [&_svg]:h-6 [&_svg]:text-text-muted">
+      <ul className="m-auto p-0 inline-flex gap-5 [&_li]:m-auto [&_li]:inline-grid [&_li>a]:inline-grid [&_li>a]:text-text-muted">
         {page > 1 && (
           <li>
             <a href={buildURL(page - 1)}>
@@ -62,7 +62,7 @@ const Paginator = ({ page, lastPage, displayCount = 5, query, baseURL }: Paginat
           <li key={pageNum}>
             <a
               href={buildURL(pageNum)}
-              className={page === pageNum ? 'bg-accent-700 py-narrow px-common rounded-[4px] !text-white' : ''}
+              className={page === pageNum ? 'bg-accent-700 py-1 px-3 rounded-md !text-white' : ''}
             >
               {pageNum}
             </a>

--- a/components/post-card/PostCard.tsx
+++ b/components/post-card/PostCard.tsx
@@ -9,10 +9,10 @@ export interface PostCardProps {
 }
 
 const PostCard = ({ titleLevel = 3, post }: PostCardProps) => (
-  <article className="clickable post-card-grid gap-common border-t border-divider py-wide">
+  <article className="clickable post-card-grid gap-3 border-t border-divider py-5">
     <a
       href={PostUtil.buildLinkURLByTitle(post.title)}
-      className="[grid-area:title] [&>*]:text-text-heading [&>*]:text-xl [&>*]:my-common"
+      className="[grid-area:title] [&>*]:text-text-heading [&>*]:text-xl [&>*]:my-3"
     >
       {titleLevel === 1 && <h1>{post.title}</h1>}
       {titleLevel === 2 && <h2>{post.title}</h2>}
@@ -29,7 +29,7 @@ const PostCard = ({ titleLevel = 3, post }: PostCardProps) => (
 
     <a
       href={PostUtil.buildLinkURLByTitle(post.title)}
-      className="[grid-area:description] [&>p]:whitespace-pre-wrap [&>p]:mt-0 [&>p]:leading-wide [&>p]:text-text-body"
+      className="[grid-area:description] [&>p]:whitespace-pre-wrap [&>p]:mt-0 [&>p]:leading-relaxed [&>p]:text-text-body"
     >
       <p>{post.description}</p>
     </a>

--- a/components/search-input/SearchInput.tsx
+++ b/components/search-input/SearchInput.tsx
@@ -7,7 +7,7 @@ const SearchInput = (props: SearchInputProps) => {
     <label className="inline-flex w-full">
       <Search className="text-text-heading m-auto" />
       <input
-        className="flex-1 border-none bg-bg-page outline-none p-narrow text-text-body"
+        className="flex-1 border-none bg-bg-page outline-none p-1 text-text-body"
         {...props}
         spellCheck={false}
       />

--- a/components/tag-indexer/TagIndexer.tsx
+++ b/components/tag-indexer/TagIndexer.tsx
@@ -23,7 +23,7 @@ const TagIndexer = (props: TagIndexerProps) => {
         </a>
       </h2>
 
-      <div className="p-common">
+      <div className="p-3">
         <Tags tags={tagsWithCount.slice(0, limit)} />
       </div>
     </section>

--- a/components/tag-list/TagList.tsx
+++ b/components/tag-list/TagList.tsx
@@ -10,7 +10,7 @@ export interface TagListProps {
 
 const TagList = (props: TagListProps) => {
   return (
-    <ol className="m-0 p-0 [&_ol]:m-0 [&_ol]:p-0 [&_h2]:text-[1.5rem] [&_h2]:pb-narrow [&_h2]:border-b [&_h2]:border-divider">
+    <ol className="m-0 p-0 [&_ol]:m-0 [&_ol]:p-0 [&_h2]:text-[1.5rem] [&_h2]:pb-1 [&_h2]:border-b [&_h2]:border-divider">
       {props.indexGroups.map((indexGroup, idx) => (
         <ol key={idx}>
           {indexGroup

--- a/components/tag-navigator/TagNavigator.tsx
+++ b/components/tag-navigator/TagNavigator.tsx
@@ -6,7 +6,7 @@ export interface TagNavigatorProps {
 const TagNavigator = (props: TagNavigatorProps) => {
   const indexesSet = new Set(props.activatedIndexes)
   return (
-    <div className="p-wide [&>ol]:m-0 [&>ol]:p-0 [&>ol_li]:inline-block [&>ol_li]:m-narrow [&>ol_li]:p-0 [&>ol_a]:text-text-muted [&>ol_a]:font-extralight">
+    <div className="p-5 [&>ol]:m-0 [&>ol]:p-0 [&>ol_li]:inline-block [&>ol_li]:m-1 [&>ol_li]:p-0 [&>ol_a]:text-text-muted [&>ol_a]:font-extralight">
       {props.indexGroups.map((indexes, keyIdx) => {
         return (
           <ol key={keyIdx}>

--- a/components/tag/Tag.tsx
+++ b/components/tag/Tag.tsx
@@ -5,7 +5,7 @@ export interface TagProps {
 
 const Tag = (props: TagProps) => (
   <a href={`/posts/1?query=${encodeURIComponent(props.tag)}`}>
-    <span className="clickable block p-2 bg-bg-subtle text-text-body ring-1 ring-border rounded-[20px] min-w-[40px] text-center cursor-pointer before:content-['#']">
+    <span className="clickable block p-2 bg-bg-subtle text-text-body ring-1 ring-border rounded-sm min-w-[40px] text-center cursor-pointer before:content-['#']">
       {props.tag} {props.count && props.count}
     </span>
   </a>

--- a/pages/[title].tsx
+++ b/pages/[title].tsx
@@ -45,7 +45,7 @@ export async function getStaticProps(context: { params: { title: string } }) {
 }
 
 const sectionHeadingClass =
-  '[&>h2]:mt-10 [&>h2]:mb-0 [&>h2]:pb-common [&>h2]:border-b [&>h2]:border-divider'
+  '[&>h2]:mt-10 [&>h2]:mb-0 [&>h2]:pb-3 [&>h2]:border-b [&>h2]:border-divider'
 
 const PostDetail: NextPage<PostDetailPageProps> = ({ post, content, postsByCategory }: PostDetailPageProps) => {
   const containerRef = useRef<HTMLElement>(null)

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -29,7 +29,7 @@ const About = ({ careerYears }: AboutProps) => {
         imageURL={'/icons/icon-512x512.png'}
       />
 
-      <article className="[&_section]:mb-8 [&_p]:ml-wide [&_p]:text-text-body [&_p]:italic">
+      <article className="[&_section]:mb-8 [&_p]:ml-5 [&_p]:text-text-body [&_p]:italic">
         <h1>About</h1>
 
         <RaiseSection timeout={standardTimeout}>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -53,7 +53,7 @@ const Home: NextPage<{
 
       <MainAdsBanner />
 
-      <div className="grid grid-cols-2 pb-wide max-tablet:grid-cols-1 max-tablet:gap-common">
+      <div className="grid grid-cols-2 pb-5 max-tablet:grid-cols-1 max-tablet:gap-3">
         <CategoryIndexer categories={props.categories} />
 
         <TagIndexer tagsWithCount={props.tagsWithCount} limit={20} />

--- a/pages/licenses/index.tsx
+++ b/pages/licenses/index.tsx
@@ -13,7 +13,7 @@ const Licenses = () => {
         {Object.keys(licenses).map((depName) => {
           return (
             <details
-              className="text-text-muted [&_summary]:py-common [&_summary]:px-0 [&_a]:text-link"
+              className="text-text-muted [&_summary]:py-3 [&_summary]:px-0 [&_a]:text-link"
               key={depName}
             >
               <summary>{depName}</summary>

--- a/pages/posts/[page].tsx
+++ b/pages/posts/[page].tsx
@@ -92,7 +92,7 @@ const Posts: NextPage<PostsProps> = (props) => {
           keywords={posts.map((post) => [...post.tags, post.title, post.description]).flat()}
         />
 
-        <span className="text-text-muted text-[0.8rem] float-right mt-wide">{query ? `Found ${posts.length}` : `Total ${totalCount}`}</span>
+        <span className="text-text-muted text-[0.8rem] float-right mt-5">{query ? `Found ${posts.length}` : `Total ${totalCount}`}</span>
         <h1>Posts </h1>
       </>
     ),

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4,11 +4,40 @@
 @theme {
   --breakpoint-tablet: 800px;
 
-  --spacing-narrow: 5px;
-  --spacing-common: 10px;
-  --spacing-wide: 20px;
+  /* ── Spacing scale (4px grid, 12 steps) ──────────────────────────────
+     px-based (not rem): preserves the legacy narrow/common/wide behavior
+     where spacing stayed fixed under the mobile `:root { font-size: 12px }`
+     rule. Step values follow the issue #146 table. */
+  --spacing-1:  4px;   /* icon↔text gap */
+  --spacing-2:  8px;   /* inline gap, tag-row gap */
+  --spacing-3:  12px;  /* chip/badge inner padding */
+  --spacing-4:  16px;  /* form gap, compact card padding */
+  --spacing-5:  20px;  /* card inner padding (standard) */
+  --spacing-6:  24px;  /* card-to-card gap */
+  --spacing-8:  32px;  /* section inner block gap */
+  --spacing-10: 40px;  /* main section separation */
+  --spacing-12: 48px;  /* section↔section */
+  --spacing-16: 64px;  /* header↔body, footer↔body */
+  --spacing-20: 80px;  /* page top/bottom */
+  --spacing-24: 96px;  /* hero↔content */
 
-  --leading-wide: var(--spacing-wide);
+  /* Semantic spacing aliases (intent-expressing). Defined per issue #146;
+     consumed by page/card/section markup in the follow-up redesign issues
+     (#149–159). Components in this change use the numeric steps directly. */
+  --spacing-card-inner:     var(--spacing-5);   /* 20 */
+  --spacing-card-gap:       var(--spacing-6);   /* 24 */
+  --spacing-section-inner:  var(--spacing-8);   /* 32 */
+  --spacing-section-gap:    var(--spacing-12);  /* 48 */
+  --spacing-page-x:         var(--spacing-6);   /* 24 — mobile L/R */
+  --spacing-page-x-desktop: var(--spacing-12);  /* 48 — desktop L/R */
+  --spacing-page-y:         var(--spacing-16);  /* 64 */
+
+  /* ── Radius scale ─────────────────────────────────────────────────── */
+  --radius-sm:   6px;     /* tags, badges, inputs */
+  --radius-md:   10px;    /* buttons */
+  --radius-lg:   14px;    /* cards */
+  --radius-xl:   20px;    /* modals, sheets */
+  --radius-full: 9999px;  /* count circles, avatars */
 
   /* ── Typography: font families ────────────────────────────────────── */
   /* next/font exposes the hashed family names through these variables
@@ -249,7 +278,7 @@
   main {
     grid-area: main;
     width: 768px;
-    padding-top: var(--spacing-wide);
+    padding-top: var(--spacing-5);
     padding-bottom: var(--footer-height);
   }
 
@@ -282,7 +311,7 @@
     main {
       margin: 0;
       width: 100%;
-      padding: var(--spacing-common) var(--spacing-wide) var(--footer-height);
+      padding: var(--spacing-3) var(--spacing-5) var(--footer-height);
     }
 
     aside {
@@ -336,18 +365,18 @@
 
   .post-body {
     & ins {
-      margin-top: 20px !important;
-      margin-bottom: 20px !important;
+      margin-top: var(--spacing-5) !important;
+      margin-bottom: var(--spacing-5) !important;
     }
 
     & ul,
     & ol {
-      padding-left: var(--spacing-wide);
+      padding-left: var(--spacing-5);
     }
 
     & ol,
     & li {
-      margin-top: var(--spacing-narrow);
+      margin-top: var(--spacing-1);
     }
 
     & li {
@@ -373,7 +402,7 @@
     & h2,
     & h3,
     & h4 {
-      padding-bottom: var(--spacing-common);
+      padding-bottom: var(--spacing-3);
       border-bottom: 1px solid var(--color-divider);
     }
 
@@ -411,7 +440,7 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      padding: var(--spacing-wide) 0;
+      padding: var(--spacing-5) 0;
       color: var(--color-text-body);
     }
 


### PR DESCRIPTION
## 요약
narrow/common/wide 3단계 스페이싱과 arbitrary 라운드 값을, 4px 그리드 12스텝 `--spacing-*` 스케일·의미 단위 alias·5단계 `--radius-*` 토큰으로 정리하고 전 컴포넌트/페이지를 신 토큰으로 마이그레이션했습니다. #144(컬러)·#145(타이포)에 이은 디자인 시스템 토대 작업입니다.

## 변경 사항
- `@theme`에 px 기반 `--spacing-1`~`--spacing-24`(12스텝), 의미 alias 7개, `--radius-sm`~`--radius-full`(5단계) 정의
- 레거시 `--spacing-narrow/common/wide`, `--leading-wide` 제거
- 14개 컴포넌트 + 5개 페이지의 레거시 클래스(`narrow→1`, `common→3`, `wide→5`) 및 arbitrary 라운드 치환
- `--space-*` 대신 `--spacing-*` namespace로 정의해 `p-1`/`gap-1` 표준 유틸 자동 생성
- px 기반 유지로 모바일(`:root{font-size:12px}`) spacing 고정 — rem 회귀 방지
- `--leading-wide` 제거에 따라 PostCard 설명 행간을 `leading-relaxed`로 교체
- `styling-gotchas.md`에 토큰 gotcha 3건(namespace/px-basis/`@theme` 전역 override) 문서화

## 관련 이슈
Closes #146

## 테스트 체크리스트
- [ ] `pnpm run lint` / `pnpm run build` 통과 (확인 완료)
- [ ] 카드 간격·섹션 간격·페이지 좌우 여백이 시각적 위계를 가짐
- [ ] 태그 칩 라운드 변화(`rounded-[20px]`→`rounded-sm`, 6px) 확인
- [ ] PostCard 썸네일 라운드 6px→10px 수용 확인 (의도된 side effect)
- [ ] 페이지네이션 활성 버튼 라운드(10px) 확인
- [ ] 모바일(≤768)·태블릿(≤800)·데스크탑 시각 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)