### PR TITLE
feat(styles): 그림자 & 모션 토큰 + clickable/focus 재정의

### DIFF
--- a/.claude/docs/index.md
+++ b/.claude/docs/index.md
@@ -11,6 +11,7 @@ Read this when: you need to find project knowledge documents written by AI agent
 | How to safely depend on dates, randomness, or other host-runtime values inside a page under `output: 'export'` | [static-export-rendering-gotchas.md](static-export-rendering-gotchas.md) |
 | How Tailwind v4 is set up here, and what classes/tokens MUST NOT be changed | [styling-gotchas.md](styling-gotchas.md) |
 | Why spacing/radius tokens are px not rem, why they are named `--spacing-*` (not `--space-*`), or why an untouched `rounded-md` element changed radius | [styling-gotchas.md](styling-gotchas.md) |
+| Why an untouched `ease-in-out`/`shadow-md` utility changed after the motion-token work, why `.clickable`'s `@layer base` transition has no effect, or why the code-block shadow depends on `--shadow-sm` | [styling-gotchas.md](styling-gotchas.md) |
 | Which color token to use where, why `accent-700` (not `accent-600`) is the light-mode link, or how dark-mode pairing works | [color-tokens-gotchas.md](color-tokens-gotchas.md) |
 | How the self-hosted fonts load, why `--text-*`/`--leading-*` tokens override Tailwind built-ins, why fonts inject from `_app.tsx` not `_document.tsx`, or why post-body headings differ from base `h1~h4` | [typography-system-gotchas.md](typography-system-gotchas.md) |
 | Why AdSense throws a fatal error at narrow viewports, and why `useIsMobile` threshold is 1100 px | [ads-adsense-rendering-gotchas.md](ads-adsense-rendering-gotchas.md) |

--- a/.claude/docs/styling-gotchas.md
+++ b/.claude/docs/styling-gotchas.md
@@ -43,6 +43,7 @@ The project styles itself with Tailwind CSS v4 in CSS-first mode (no `tailwind.c
 - **Symptom:** Tweaking a hljs token color in `globals.css` has no effect, or vice versa.
 - **Why:** `styles/highlight.css` is imported in `pages/_app.tsx` AFTER `globals.css` and is plain CSS (not a Tailwind layer). It owns `.hljs`, `.hljs-*`, and the `pre code` reset, and it is loaded last so it overrides preflight on code blocks.
 - **Rule:** Add or change syntax-highlight colors in `highlight.css` only. Add or change layout/typography for code blocks (e.g., border-radius on `<pre>`) also in `highlight.css`. NEVER move hljs rules into `globals.css` — the import order matters.
+- **Cross-file dependency:** `.hljs` consumes `var(--shadow-sm)` (a `@theme` shadow token defined in `globals.css`, issue #147) for its light-mode box-shadow, with `box-shadow: none` in dark mode. Renaming or removing shadow tokens in `globals.css` silently breaks the code-block shadow here — `highlight.css` is plain CSS, so an undefined `var()` just drops the shadow with no error. (This is the trap that bit the old `--common-shadow` token: it was assumed unused but was consumed here.)
 
 ### Token names must follow Tailwind v4's `--<namespace>-<name>` convention
 
@@ -61,6 +62,18 @@ The project styles itself with Tailwind CSS v4 in CSS-first mode (no `tailwind.c
 - **Symptom:** An element you never touched (e.g. the PostCard thumbnail's `rounded-md`) suddenly renders with a different radius/spacing after a token change.
 - **Why:** `@theme` token values override Tailwind's built-in scale. Defining `--radius-md: 10px` / `--radius-sm: 6px` (issue #146) replaces the defaults (`md`=6px, `sm`=4px), so EVERY existing `rounded-md`/`rounded-sm` consumer — even ones not in your diff — re-renders at the new value. Same applies to `--spacing-*`.
 - **Rule:** When choosing scale-token values, account for the blast radius across all existing standard-class consumers, not just the lines you edit. To restyle only some elements, use an arbitrary value or a distinct token instead of redefining the shared scale token.
+
+### `--ease-*` / `--shadow-*` tokens in `@theme` override Tailwind's built-in utilities globally
+
+- **Symptom:** An `ease-in-out` or `shadow-md` utility you never touched animates/renders differently after the motion-token change (issue #147); e.g. a hover transition feels springier than the CSS standard `ease-in-out`.
+- **Why:** `--ease-*` and `--shadow-*` are registered Tailwind namespaces. Defining `--ease-out`/`--ease-in-out`/`--ease-spring`/`--ease-linear` and `--shadow-xs…lg` in `@theme` (issue #147) **replaces** the values backing the built-in `ease-*`/`shadow-*` utilities. Existing consumers re-render with the new curves/shadows — e.g. `components/content-explorer/ContentExplorer.tsx`'s `[&_a]:ease-in-out` now resolves to `cubic-bezier(0.65, 0, 0.35, 1)` instead of CSS-standard `ease-in-out`. This is intentional (one site-wide motion vocabulary) but the blast radius reaches every `ease-*`/`shadow-*` utility consumer, not just new code.
+- **Rule:** Treat `--ease-*`/`--shadow-*` like the `--radius-*`/`--spacing-*` scale (see above) — redefining them is a global override. The motion tokens (`--duration-*`, `--ease-*`) are consumed via `var()` in transition declarations, NOT as utilities; `--shadow-*` is consumed both as `shadow-*` utilities AND via `var()`. When changing a token value, account for all existing standard-class consumers. To apply a one-off easing/shadow without touching the global vocabulary, use an arbitrary value instead of redefining the token.
+
+### `@utility` rules override `@layer base` declarations for the same selector
+
+- **Symptom:** A property you declared for an element in `@layer base` (e.g. the `.clickable` `transition` baseline) silently has no effect.
+- **Why:** Tailwind v4 emits `@utility` definitions into the `utilities` layer, which beats `@layer base` in the cascade-layer order regardless of specificity. `@utility clickable`'s own `transition` (transform + box-shadow only) fully overrides any `.clickable` `transition` set in `@layer base`. This is why `.clickable` is intentionally **absent** from the shared interactive-element transition selector list in `@layer base` — including it would create a dead, misleading declaration.
+- **Rule:** When an element has both a `@utility` definition and a `@layer base` rule for the same property, the `@utility` wins. Do NOT add a selector to a `@layer base` rule if that same selector's `@utility` already sets the property — put the full intended value in the `@utility` instead.
 
 ## Conventions
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -114,12 +114,42 @@
 
   /* Kept: referenced by .prose.post-body --tw-prose-pre-bg */
   --color-code-bg: #212836;
+
+  /* ── Shadow scale (light mode) ────────────────────────────────────────
+     Semantic mapping: xs=input emphasis, sm=card resting, md=card hover /
+     dropdown, lg=modal / popover / sheet, focus=:focus-visible ring.
+     Dark-mode values are redefined in the @media block below as a white
+     hairline ring + shadow combo (black shadows vanish on dark surfaces). */
+  --shadow-xs:    0 1px 2px 0 rgb(0 0 0 / 0.04);
+  --shadow-sm:    0 1px 3px 0 rgb(0 0 0 / 0.06),
+                  0 1px 2px -1px rgb(0 0 0 / 0.04);
+  --shadow-md:    0 4px 12px -2px rgb(0 0 0 / 0.08),
+                  0 2px 4px -2px rgb(0 0 0 / 0.04);
+  --shadow-lg:    0 12px 24px -6px rgb(0 0 0 / 0.10),
+                  0 4px 8px -4px rgb(0 0 0 / 0.04);
+  /* Reuses --color-focus-ring (accent-500 @ 35%); accent is light-invariant
+     so this needs no dark-mode override. */
+  --shadow-focus: 0 0 0 3px var(--color-focus-ring);
+
+  /* ── Motion tokens ────────────────────────────────────────────────────
+     Consumed via var() in transition declarations (not as utilities).
+     --ease-* matches Tailwind's ease-* namespace, intentionally overriding
+     the built-in easing utilities. spring is reserved for explicit emphasis
+     (never hover). */
+  --duration-instant: 80ms;    /* immediate feedback (active press) */
+  --duration-fast:    150ms;   /* hover, focus */
+  --duration-base:    200ms;   /* card lift, background swap */
+  --duration-slow:    280ms;   /* modal enter */
+  --duration-slower:  400ms;   /* page transition */
+
+  --ease-out:    cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-linear: linear;
 }
 
 @layer base {
   :root {
-    /* Consumed by styles/highlight.css (pre code box-shadow) */
-    --common-shadow: 2px 2px 2px var(--color-border);
     --header-height: 140px;
     --footer-height: 50px;
   }
@@ -141,6 +171,17 @@
       /* Dark-mode links use brighter teal */
       --color-link:       var(--color-accent-400);
       --color-link-hover: var(--color-accent-500);
+
+      /* Black shadows are near-invisible on dark surfaces, so each step pairs
+         a white hairline ring (surface separation) with a deeper shadow.
+         --shadow-focus is omitted: accent is light-invariant. */
+      --shadow-xs: 0 0 0 1px rgb(255 255 255 / 0.04);
+      --shadow-sm: 0 0 0 1px rgb(255 255 255 / 0.06),
+                   0 1px 2px 0 rgb(0 0 0 / 0.4);
+      --shadow-md: 0 0 0 1px rgb(255 255 255 / 0.06),
+                   0 6px 16px -4px rgb(0 0 0 / 0.5);
+      --shadow-lg: 0 0 0 1px rgb(255 255 255 / 0.08),
+                   0 12px 32px -8px rgb(0 0 0 / 0.6);
     }
   }
 
@@ -171,6 +212,34 @@
      ported as-is. */
   :focus:not(:focus-visible) {
     outline: none;
+  }
+
+  /* Keyboard focus ring: accent 3px ring that follows the element's radius.
+     Pairs with the mouse-click suppression above. */
+  :focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus);
+    border-radius: var(--radius-sm);
+    transition: box-shadow var(--duration-instant) var(--ease-out);
+  }
+
+  /* Shared transition baseline for interactive elements. transform uses the
+     slower --duration-base (lift feels deliberate); the rest react fast.
+     .clickable is intentionally absent: the @utility clickable below sits in
+     the utilities layer and fully overrides this transition for it. */
+  a,
+  button,
+  [role="button"],
+  input,
+  select,
+  textarea {
+    transition:
+      color            var(--duration-fast) var(--ease-out),
+      background-color var(--duration-fast) var(--ease-out),
+      border-color     var(--duration-fast) var(--ease-out),
+      box-shadow       var(--duration-fast) var(--ease-out),
+      transform        var(--duration-base) var(--ease-out),
+      opacity          var(--duration-fast) var(--ease-out);
   }
 
   a {
@@ -318,12 +387,55 @@
       display: none;
     }
   }
+
+  /* Honor OS-level Reduce Motion: collapse animations/transitions to ~instant
+     instead of removing them outright (avoids breaking JS that waits on
+     transitionend). */
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
 }
 
+/* Hover-driven lift: rests flat, lifts 2px + md shadow on hover, snaps back
+   instantly on press. Replaces the prior :active-only scale(1.05) which gave
+   no hover feedback. */
 @utility clickable {
-  transition: transform 0.2s ease-in-out 0s;
+  cursor: pointer;
+  transition:
+    transform  var(--duration-base) var(--ease-out),
+    box-shadow var(--duration-base) var(--ease-out);
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+  }
   &:active {
-    transform: scale(1.05);
+    transform: translateY(0);
+    transition-duration: var(--duration-instant);
+  }
+}
+
+/* Restrained card lift (1px) gated behind hover-capable pointers so touch
+   devices don't get a stuck hover state. Applied to card components in the
+   page-redesign issues, not here. */
+@utility card-hover {
+  transition:
+    transform    var(--duration-base) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out),
+    box-shadow   var(--duration-base) var(--ease-out);
+
+  @media (hover: hover) {
+    &:hover {
+      transform: translateY(-1px);
+      box-shadow: var(--shadow-md);
+    }
   }
 }
 

--- a/styles/highlight.css
+++ b/styles/highlight.css
@@ -10,7 +10,7 @@ pre code {
   background: var(--color-code-bg);
   color: #fff;
   border-radius: 4px;
-  box-shadow: var(--common-shadow);
+  box-shadow: var(--shadow-sm);
 
   @media (prefers-color-scheme: dark) {
     box-shadow: none;


### PR DESCRIPTION
## 요약
디자인 시스템 토대 작업의 마지막 단계(#144 컬러·#145 타이포·#146 스페이싱에 이은).
그림자/모션 토큰을 도입하고, hover 피드백이 없던 clickable과 전역 focus 스타일을 재정의했다.

## 변경 사항
- `@theme`에 그림자 토큰(`--shadow-xs/sm/md/lg/focus`) 추가, 다크모드는 hairline-ring 조합으로 오버라이드
- `@theme`에 모션 토큰(`--duration-*`, `--ease-*`) 추가
- `@layer base`에 interactive 요소 전역 transition, `:focus-visible` 액센트 링, `prefers-reduced-motion` 분기 추가
- `clickable` 유틸리티를 hover-lift + active 즉시 원위치 패턴으로 재정의
- `card-hover` 유틸리티 신설(`@media (hover: hover)` 분기로 터치 환경 lift 제거)
- 미사용으로 알려졌던 `--common-shadow` 제거 — 실제로 `highlight.css`가 소비 중이어서 사용처를 `--shadow-sm`으로 대체
- `styling-gotchas.md`에 토큰 오버라이드 blast radius · `@utility`/`@layer` cascade · highlight.css 교차 의존성 gotcha 문서화

## 관련 이슈
Closes #147

## 테스트 체크리스트
- [ ] 카드/링크 hover 시 lift + 그림자 피드백이 즉시 인지되고 과하지 않음
- [ ] 키보드 Tab 이동 시 액센트 포커스 링이 명확히 보임
- [ ] 다크모드에서 코드블록 그림자 제거 + 카드 면 구분(ring) 정상
- [ ] macOS Reduce Motion 설정 시 transition이 즉시 적용됨
- [ ] 모바일 터치 환경에서 card-hover lift가 동작하지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)