### PR TITLE
feat(layout): 공통 컨테이너 + 슬림 헤더 + static 푸터 도입

### DIFF
--- a/.claude/docs/index.md
+++ b/.claude/docs/index.md
@@ -10,6 +10,7 @@ Read this when: you need to find project knowledge documents written by AI agent
 | Why a lucide icon won't size via `font-size`, or where a brand icon went | [icon-library-gotchas.md](icon-library-gotchas.md) |
 | How to safely depend on dates, randomness, or other host-runtime values inside a page under `output: 'export'` | [static-export-rendering-gotchas.md](static-export-rendering-gotchas.md) |
 | How Tailwind v4 is set up here, and what classes/tokens MUST NOT be changed | [styling-gotchas.md](styling-gotchas.md) |
+| How the page skeleton/containers/slim header/static footer work, which `.container-*` a page uses, why the app-global aside is gone, or why the layout breakpoint is 767/1024 | [layout-system-gotchas.md](layout-system-gotchas.md) |
 | Why spacing/radius tokens are px not rem, why they are named `--spacing-*` (not `--space-*`), or why an untouched `rounded-md` element changed radius | [styling-gotchas.md](styling-gotchas.md) |
 | Why an untouched `ease-in-out`/`shadow-md` utility changed after the motion-token work, why `.clickable`'s `@layer base` transition has no effect, or why the code-block shadow depends on `--shadow-sm` | [styling-gotchas.md](styling-gotchas.md) |
 | Which color token to use where, why `accent-700` (not `accent-600`) is the light-mode link, or how dark-mode pairing works | [color-tokens-gotchas.md](color-tokens-gotchas.md) |

--- a/.claude/docs/layout-system-gotchas.md
+++ b/.claude/docs/layout-system-gotchas.md
@@ -1,0 +1,50 @@
+# Layout System Gotchas
+
+Read this when: editing the page skeleton in `pages/_app.tsx`, the `header`/`main`/`footer` base rules or `.container-*`/`.layout-with-aside` utilities in `styles/globals.css`, wrapping a page in a container, or touching `Header.tsx`/`Footer.tsx`/`NavBar.tsx` layout.
+
+## Overview
+
+The common layout (issue #149) is a flex skeleton in `pages/_app.tsx` — `min-h-dvh flex flex-col` wrapping `Header` / `<main className="flex-1">` / `Footer` — that replaced the legacy `#__next` 3-column grid. Pages opt into one of three width containers, with a slim sticky header and a static footer. This doc covers the traps in that layer.
+
+## Pitfalls
+
+### `*/` inside a CSS block comment closes it early
+
+- **Symptom:** `pnpm run build` fails with `Syntax error: Unknown word --header-height` (or similar) pointing at a token line that looks fine.
+- **Why:** A `/* ... */` comment in `globals.css` that contains the literal `*/` — e.g. writing `--spacing-*/--radius-*` in prose — terminates the comment at that `*/`, so the rest of the comment body is parsed as CSS and breaks.
+- **Rule:** NEVER write `*/` inside a CSS comment. Rephrase (e.g. "the spacing/radius scale tokens") instead of `--spacing-*/--radius-*`.
+
+### Bare JSX comment as the first child of `return (` is a parse error
+
+- **Symptom:** ESLint/`tsc` fails with `Parsing error: ')' expected` in a component you just edited.
+- **Why:** `{/* ... */}` placed directly after `return (` as a sibling of the root element is an expression in an invalid position — there is no enclosing element to hold it.
+- **Rule:** Put the comment as a plain `// ...` JS comment ABOVE `return`, or inside the root element. NEVER leave a `{/* */}` as the bare first node of a return.
+
+### Header/footer background & border have ONE owner — the base rule
+
+- **Symptom:** A doubled border under the header/footer, OR the header backdrop-blur shows no blur-through (looks opaque).
+- **Why:** The base `header`/`footer` rules in `globals.css` own `background-color` (header uses a translucent `color-mix` so `backdrop-filter: blur` shows through), `border`, and footer spacing. If `Header.tsx`/`Footer.tsx` ALSO set `bg-bg-page` (opaque) or `border-b border-divider`, the opaque bg defeats the blur and the divider token drifts from the base rule's `--color-border`.
+- **Rule:** Keep `Header.tsx`/`Footer.tsx` free of background/border classes — the base rule owns them. The header background MUST stay semi-transparent for the blur effect.
+
+### Header horizontal padding MUST track `.container-*` padding
+
+- **Symptom:** On desktop ≥1024px the header title/icons sit at a different left/right edge than page content — a staggered vertical edge.
+- **Why:** `.container-*` uses `--spacing-page-x` (24) that bumps to `--spacing-page-x-desktop` (48) at `min-width: 1024px`. If the header uses a fixed `px-6`, it stays at 24 while content moves to 48.
+- **Rule:** The base `header` rule sets `padding-inline: var(--spacing-page-x)` with a `@media (min-width: 1024px)` bump to `var(--spacing-page-x-desktop)` — identical to the containers. Do NOT hardcode header padding in `Header.tsx`.
+
+### The app-global aside is gone — `enableContentExplorer` is currently dead
+
+- **Symptom:** Looking for where `ContentExplorer` (post TOC) or `AsideAdsBanner` renders and finding nothing; `pageProps.enableContentExplorer` has no consumer.
+- **Why:** Issue #149 removed the `<aside>` from `_app.tsx` (the issue's own skeleton has none). `ContentExplorer` rework is deferred to #153; `AsideAdsBanner` re-placement to the follow-up aside-composition issues (2-2/2-3). The `enableContentExplorer` prop on `pages/[title].tsx` is intentionally kept as the wiring point for #153 but reads nowhere today.
+- **Rule:** To add an aside, compose `.layout-with-aside` inside the page's container (it is defined but applied to no page). Do NOT re-add an app-global aside to `_app.tsx`.
+
+## Conventions
+
+- Layout tokens (`--header-height` 64, `--header-height-mobile` 56, `--container-reading-max` 720, `--container-content-max` 1120, `--container-wide-max` 1280, `--aside-width` 280) live in `@theme` and are consumed only via `var()` — they are NOT utility namespaces, so they carry no blast radius (unlike the `--spacing-*`/`--radius-*` scales; see [styling-gotchas.md](styling-gotchas.md)).
+- Every page MUST wrap its top-level element in exactly one container: `container-reading` (720, long-form prose — post/about/licenses/404), `container-content` (1120, card/list pages — index/posts/categories/tags), or `container-wide` (1280, reserved). `<main className="flex-1">` in `_app.tsx` owns vertical flex; the container owns horizontal width/padding.
+- The static footer is pinned to the viewport bottom on short pages by the skeleton (`min-h-dvh flex flex-col` + `main flex-1`), NOT by `position: fixed`. NEVER reintroduce `position: fixed` on the footer.
+- Responsive model is three-tier: **≤767** mobile (single column, `:root { font-size: 12px }`, 56px header), **768–1023** tablet (single column, container padding bumps at 1024), **≥1024** desktop (`.layout-with-aside` grid active). The base-layer mobile `@media` boundary is `max-width: 767px`. Component-internal reflows keep using the `max-tablet:` (800px) variant — see [styling-gotchas.md](styling-gotchas.md).
+
+## Rationale
+
+The legacy `#__next` `repeat(3, 1fr)` grid with a hardcoded `main { width: 768px }` pinned content to the right third of wide viewports and forced the aside to `display: none` on mobile. The container model decouples reading width from viewport thirds and lets the aside reflow instead of vanish. Header slot details (logo/search/mobile sheet) and footer content expansion are deferred to issues #150 and the footer-redesign issue respectively.

--- a/.claude/docs/styling-gotchas.md
+++ b/.claude/docs/styling-gotchas.md
@@ -30,7 +30,7 @@ The project styles itself with Tailwind CSS v4 in CSS-first mode (no `tailwind.c
 
 - **Symptom:** A new component uses `md:` for its tablet break and looks wrong at 769–800 px.
 - **Why:** Tailwind's default `md` breakpoint is 768 px. The legacy stylesheets used `@media (max-width: 800px)` for layout reflows (header rearrange, post-card stacking, aside hide). To preserve the exact reflow points, `@theme` defines `--breakpoint-tablet: 800px`, exposing the `tablet:` and `max-tablet:` variants.
-- **Rule:** Use `max-tablet:` for legacy 800 px reflows. `max-md:` (768 px) is reserved for the rarer 768 px breakpoint already present in `globals.css` `@layer base` (`#__next`, mobile font-size, aside hide).
+- **Rule:** Use `max-tablet:` for component-internal reflows (header gap, post-card stacking, hero image) — these stayed on 800 px. The base-layer *layout* `@media` blocks were consolidated to the three-tier 767/1024 model in issue #149 (mobile boundary is now `max-width: 767px`, not 768; the `#__next` grid and `aside { display: none }` were removed). Do NOT reintroduce a 768 px layout breakpoint. See [layout-system-gotchas.md](layout-system-gotchas.md).
 
 ### Complex `grid-template-areas` belong in `@layer components`, not inline
 
@@ -88,7 +88,8 @@ The project styles itself with Tailwind CSS v4 in CSS-first mode (no `tailwind.c
 - [typography-system-gotchas.md](typography-system-gotchas.md) — font loading and type-scale tokens (`--font-*`/`--text-*`/`--leading-*`/`--tracking-*`) layered on this `@theme` setup; covers how post-body headings (prose utilities layer) differ from the base `h1~h4` rules documented here.
 - [color-tokens-gotchas.md](color-tokens-gotchas.md) — semantic color token conventions layered on top of the `@theme` setup documented here (Zinc/Teal primitives, semantic-only consumption rule, WCAG AA notes).
 - [dark-mode-toggle-gotchas.md](dark-mode-toggle-gotchas.md) — the `next-themes` `.dark` class strategy that the dark-mode token overrides and `highlight.css` `.dark` rules depend on.
-- [ads-adsense-rendering-gotchas.md](ads-adsense-rendering-gotchas.md) — pitfalls when the aside cell becomes too narrow for AdSense (ties into the `repeat(3, 1fr)` + fixed-width main grid behavior documented above).
+- [layout-system-gotchas.md](layout-system-gotchas.md) — the page skeleton, `.container-*`/`.layout-with-aside` utilities, slim sticky header, and static footer (issue #149) that replaced the legacy `#__next` grid; covers the 767/1024 three-tier breakpoint model referenced above.
+- [ads-adsense-rendering-gotchas.md](ads-adsense-rendering-gotchas.md) — pitfalls when an aside cell becomes too narrow for AdSense (note: the app-global aside was removed in #149; aside ads are deferred to a follow-up issue).
 
 ## Rationale
 

--- a/components/content-explorer/ContentExplorer.tsx
+++ b/components/content-explorer/ContentExplorer.tsx
@@ -67,7 +67,7 @@ const ContentExplorer = () => {
     const headingElements = getHeadingElements()
     if (!headingElements.length) return
 
-    const HEADER_HEIGHT = 140
+    const HEADER_HEIGHT = 64
     const TOP_MARGIN = 20
     const BOUNDARY = 10
     const PADDING = HEADER_HEIGHT + TOP_MARGIN + BOUNDARY

--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -3,9 +3,12 @@ export interface FooterProps {
   message?: string
 }
 
+// Static footer (issue #149): border-top, padding, and top margin live in the
+// base `footer` rule (globals.css). Keep this element class-free of border/bg to
+// avoid a doubled border / token drift.
 const Footer = (props: FooterProps) => {
   return (
-    <footer className="border-t border-divider bg-bg-page">
+    <footer>
       <p className="text-center text-text-muted font-thin">
         {props.message ? props.message : `ⓒ 2021. ${props.author}  all rights reserved.`}
       </p>

--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -15,13 +15,19 @@ export interface HeaderProps {
 }
 
 const Header = ({ title, menus, socialIcons }: HeaderProps) => {
+  // Single-row layout fitted to the 64px slim header (issue #149): title left,
+  // nav centered (flex-1), social + theme toggle right. Background/border live
+  // in the base `header` rule (globals.css) so the backdrop-blur shows through —
+  // do NOT add an opaque bg here. Logo/search/mobile-sheet slots come in #150.
   return (
-    <header className="header-grid pb-5 border-b border-divider bg-bg-page max-tablet:pb-0 max-tablet:[&>nav]:m-auto">
-      <span className="[grid-area:title] font-bold text-3xl text-center m-auto text-text-heading max-tablet:text-2xl max-tablet:text-left max-tablet:my-auto max-tablet:mx-0 max-tablet:p-3">
+    <header className="flex items-center gap-4 max-tablet:gap-2">
+      <span className="shrink-0 font-bold text-xl text-text-heading whitespace-nowrap max-tablet:text-lg">
         {title}
       </span>
 
-      <ul className="[grid-area:socialIcons] p-5 flex gap-3 m-auto [&_li]:my-auto [&_svg]:w-6 [&_svg]:h-6 max-tablet:p-3">
+      <NavBar menus={menus} />
+
+      <ul className="shrink-0 flex items-center gap-3 [&_li]:flex [&_svg]:w-5 [&_svg]:h-5">
         {socialIcons.map((socialIcon, idx) => (
           <li key={idx}>
             <a href={socialIcon.href} target="_blank" rel="noreferrer" aria-label={socialIcon.label}>
@@ -29,14 +35,12 @@ const Header = ({ title, menus, socialIcons }: HeaderProps) => {
             </a>
           </li>
         ))}
-        {/* Shares the social-icon slot so it stays visible on the tablet (≤800px)
-            one-row layout. The ul's `[&_svg]:w-6 [&_svg]:h-6` sizes the toggle icon. */}
+        {/* Shares the social-icon slot so the toggle stays inline; the ul's
+            `[&_svg]:w-5 [&_svg]:h-5` sizes the toggle icon to match. */}
         <li>
           <ThemeToggle />
         </li>
       </ul>
-
-      <NavBar menus={menus} />
     </header>
   )
 }

--- a/components/nav-bar/NavBar.tsx
+++ b/components/nav-bar/NavBar.tsx
@@ -15,7 +15,7 @@ const NavBar = (props: NavBarProps) => {
   const router = useRouter()
 
   return (
-    <nav className="[grid-area:navBar] text-center">
+    <nav className="flex-1 text-center">
       <ul className="inline-flex gap-5 m-auto p-0 font-medium">
         {menus.map(({ display, route }, idx) => (
           <li className="clickable" key={idx}>

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -6,7 +6,7 @@ import TitleUtil from '../utils/TitleUtil'
 
 const NotFound = () => {
   return (
-    <>
+    <div className="container-reading">
       <CommonMeta
         title={TitleUtil.buildPageTitle(META_CONTENTS.NOT_FOUND.TITLE)}
         description={META_CONTENTS.NOT_FOUND.DESCRIPTION}
@@ -16,9 +16,9 @@ const NotFound = () => {
       <section>
         <h1>Page Not Found</h1>
       </section>
-      
+
       <MainAdsBanner />
-    </>
+    </div>
   )
 }
 

--- a/pages/[title].tsx
+++ b/pages/[title].tsx
@@ -21,6 +21,9 @@ export interface PostDetailPageProps {
   post: Post
   content: string
   postsByCategory: Post[]
+  /* Currently unconsumed: the app-global aside that read this was removed in
+     issue #149. Kept as the wiring point for the ContentExplorer TOC rework
+     in #153 (post detail redesign). */
   enableContentExplorer: boolean
 }
 
@@ -55,7 +58,7 @@ const PostDetail: NextPage<PostDetailPageProps> = ({ post, content, postsByCateg
   }, [])
 
   return (
-    <>
+    <div className="container-reading">
       <CommonMeta
         title={TitleUtil.buildPageTitle(META_CONTENTS.POST.TITLE(post.title))}
         description={META_CONTENTS.POST.DESCRIPTION(post.title, post.description, post.category, post.tags)}
@@ -117,7 +120,7 @@ const PostDetail: NextPage<PostDetailPageProps> = ({ post, content, postsByCateg
         <h2>댓글</h2>
         <Utterances repo={'code-logs/code-logs.github.io'} theme={'preferred-color-scheme'} issueTerm={'title'} issueLabel={'Comment'} />
       </section>
-    </>
+    </div>
   )
 }
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,5 @@
 import type { AppProps } from 'next/app'
 import { ThemeProvider } from 'next-themes'
-import AsideAdsBanner from '../components/ads-banner/AsideAdsBanner'
-import ContentExplorer from '../components/content-explorer/ContentExplorer'
 import Footer from '../components/footer/Footer'
 import GTagScript from '../components/gtag-script/GTagScript'
 import Header from '../components/header/Header'
@@ -10,41 +8,33 @@ import SWScript from '../components/sw-script/SWScript'
 import blogConfig from '../config/blog.config'
 import menus from '../config/menu.config'
 import socialIcons from '../config/social.config'
-import useIsMobile from '../hooks/useIsMobile'
 import { fontVariables } from '../styles/fonts'
 import '../styles/globals.css'
 import '../styles/highlight.css'
 
 const MainApp = ({ Component, pageProps }: AppProps) => {
-  const isMobile = useIsMobile(true)
-
   return (
-    // ThemeProvider sits outside the `display: contents` wrapper: it renders no
-    // DOM (Context only), so the `#__next` 3-column grid is unaffected. It sets
-    // `.dark` on <html> (attribute="class") to drive the token flip in
-    // globals.css; System mode resolves via prefers-color-scheme, and
-    // disableTransitionOnChange suppresses the global transition flash on swap.
+    // ThemeProvider renders no DOM (Context only) — it sets `.dark` on <html>
+    // (attribute="class") to drive the token flip in globals.css. System mode
+    // resolves via prefers-color-scheme; disableTransitionOnChange suppresses
+    // the global transition flash on theme swap.
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
-      {/* Font CSS variables are injected here, not in `_document.tsx`: next/font
-          must be loaded from `_app`/pages, and the body className would otherwise
-          need a wrapper. `display: contents` keeps header/main/aside/footer as
-          direct grid items of `#__next` while still exposing the variables to them.
-          `role="none"` neutralizes the box that `display: contents` drops from the
-          a11y tree, so the landmark children below remain the only exposed regions. */}
-      <div className={fontVariables} style={{ display: 'contents' }} role="none">
+      {/* Page skeleton (issue #149): a real flex column replaces the legacy
+          `#__next` grid. `min-h-dvh` + `flex-1` main keep the static footer at
+          the viewport bottom on short pages. The font CSS variables ride on this
+          container (next/font must load from `_app`/pages); a real flex box still
+          propagates them to descendants. The app-global aside was removed here —
+          aside content (ContentExplorer/ads) is recomposed per-page in follow-up
+          issues (#153 / 2-2 / 2-3). */}
+      <div className={`${fontVariables} min-h-dvh flex flex-col`}>
         <GTagScript gaID={blogConfig.googleAnalytics.id} />
         <NaverAnalyticsScript issuedId={blogConfig.naverAnalytics.id} />
         <SWScript />
         <Header title={blogConfig.title} socialIcons={socialIcons} menus={menus} />
 
-        <main>
+        <main className="flex-1">
           <Component {...pageProps} />
         </main>
-
-        <aside>
-          {!isMobile && pageProps?.enableContentExplorer && <ContentExplorer />}
-          {!isMobile && <AsideAdsBanner />}
-        </aside>
 
         <Footer author={blogConfig.author} />
       </div>

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -21,7 +21,7 @@ interface AboutProps {
 
 const About = ({ careerYears }: AboutProps) => {
   return (
-    <>
+    <div className="container-reading">
       <CommonMeta
         title={TitleUtil.buildPageTitle(META_CONTENTS.ABOUT.TITLE)}
         description={META_CONTENTS.ABOUT.DESCRIPTION}
@@ -70,7 +70,7 @@ const About = ({ careerYears }: AboutProps) => {
       </article>
 
       <MainAdsBanner />
-    </>
+    </div>
   )
 }
 

--- a/pages/categories/[category]/[page].tsx
+++ b/pages/categories/[category]/[page].tsx
@@ -61,7 +61,7 @@ const Category: NextPage<{
   const { page, lastPage, posts, category } = props
 
   return (
-    <>
+    <div className="container-content">
       <CommonMeta
         title={TitleUtil.buildPageTitle(META_CONTENTS.CATEGORIES.TITLE(category))}
         description={META_CONTENTS.CATEGORIES.DESCRIPTION(category, page)}
@@ -77,7 +77,7 @@ const Category: NextPage<{
       <MainAdsBanner />
 
       <Paginator page={page} lastPage={lastPage} baseURL={`${blogConfig.baseURL}/categories/${category}`} />
-    </>
+    </div>
   )
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -38,7 +38,7 @@ const Home: NextPage<{
   tagsWithCount: TagWithCount[]
 }> = (props) => {
   return (
-    <>
+    <div className="container-content">
       <CommonMeta
         title={TitleUtil.buildPageTitle(META_CONTENTS.MAIN.TITLE)}
         description={META_CONTENTS.MAIN.DESCRIPTION}
@@ -58,7 +58,7 @@ const Home: NextPage<{
 
         <TagIndexer tagsWithCount={props.tagsWithCount} limit={20} />
       </div>
-    </>
+    </div>
   )
 }
 

--- a/pages/licenses/index.tsx
+++ b/pages/licenses/index.tsx
@@ -7,7 +7,7 @@ import licenses from '../../public/licenses.json'
 
 const Licenses = () => {
   return (
-    <>
+    <div className="container-reading">
       <h1>Licenses</h1>
       <RaiseSection className="grid grid-cols-2 overflow-auto">
         {Object.keys(licenses).map((depName) => {
@@ -33,7 +33,7 @@ const Licenses = () => {
       </RaiseSection>
 
       <MainAdsBanner />
-    </>
+    </div>
   )
 }
 

--- a/pages/posts/[page].tsx
+++ b/pages/posts/[page].tsx
@@ -99,10 +99,10 @@ const Posts: NextPage<PostsProps> = (props) => {
     [page, posts, query, totalCount]
   )
 
-  if (!pageInitialized) return renderCommonFragment()
+  if (!pageInitialized) return <div className="container-content">{renderCommonFragment()}</div>
 
   return (
-    <>
+    <div className="container-content">
       {renderCommonFragment()}
 
       <form
@@ -131,7 +131,7 @@ const Posts: NextPage<PostsProps> = (props) => {
       )}
 
       {query && !posts.length && <NoFoundPosting condition={query} />}
-    </>
+    </div>
   )
 }
 

--- a/pages/tags/index.tsx
+++ b/pages/tags/index.tsx
@@ -77,7 +77,7 @@ const Tags: NextPage<{ tags: string[] }> = ({ tags }) => {
   }, [] as string[])
 
   return (
-    <section>
+    <section className="container-content">
       <CommonMeta
         title={TitleUtil.buildPageTitle(META_CONTENTS.TAGS.TITLE)}
         description={META_CONTENTS.TAGS.DESCRIPTION}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -32,6 +32,19 @@
   --spacing-page-x-desktop: var(--spacing-12);  /* 48 — desktop L/R */
   --spacing-page-y:         var(--spacing-16);  /* 64 */
 
+  /* ── Layout tokens (issue #149) ──────────────────────────────────────
+     Consumed only via var() (header height drives scroll-margin + sticky
+     offset; container maxes cap reading/content/wide widths; aside-width
+     sizes the layout-with-aside grid column). These are not utility
+     namespaces, so they carry no blast radius like the spacing/radius
+     scale tokens do. */
+  --header-height:          64px;
+  --header-height-mobile:   56px;
+  --container-reading-max:  720px;
+  --container-content-max: 1120px;
+  --container-wide-max:    1280px;
+  --aside-width:            280px;
+
   /* ── Radius scale ─────────────────────────────────────────────────── */
   --radius-sm:   6px;     /* tags, badges, inputs */
   --radius-md:   10px;    /* buttons */
@@ -41,7 +54,7 @@
 
   /* ── Typography: font families ────────────────────────────────────── */
   /* next/font exposes the hashed family names through these variables
-     (see styles/fonts.ts, injected on a display:contents wrapper in _app).
+     (see styles/fonts.ts, injected on the top-level flex wrapper in _app).
      Latin glyphs resolve to Geist; Korean glyphs fall through to Pretendard. */
   --font-sans: var(--font-geist), var(--font-pretendard), -apple-system, BlinkMacSystemFont,
     "Segoe UI", Roboto, system-ui, sans-serif;
@@ -156,10 +169,8 @@
 @variant dark (&:where(.dark, .dark *));
 
 @layer base {
-  :root {
-    --header-height: 140px;
-    --footer-height: 50px;
-  }
+  /* --header-height / --header-height-mobile now live in @theme (issue #149);
+     --footer-height was removed with the fixed→static footer migration. */
 
   /* Dark mode: only neutrals and link semantics flip. Accent tokens stay
      identical in both modes — the Teal palette is light-invariant.
@@ -330,70 +341,63 @@
   h2,
   h3,
   h4 {
-    scroll-margin-top: calc(var(--header-height) + 20px);
+    scroll-margin-top: calc(var(--header-height) + var(--spacing-5));
   }
 
   li {
     list-style: none;
   }
 
-  #__next {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    grid-template-areas: 'header header header' '. main aside' 'footer footer footer';
-  }
-
+  /* Slim sticky header (issue #149): 64px desktop / 56px mobile. The
+     semi-transparent bg + backdrop-blur let content scroll under a frosted
+     bar. Background/border own a single source of truth here — Header.tsx
+     must NOT also set an opaque bg (it would defeat the blur-through). */
   header {
-    grid-area: header;
     height: var(--header-height);
     position: sticky;
-    left: 0;
-    right: 0;
     top: 0;
-    z-index: 1;
+    z-index: 10;
+    background-color: color-mix(in oklab, var(--color-bg-page) 80%, transparent);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--color-border);
+    /* Match the .container-* horizontal padding so the header's title/nav/icons
+       align with page content's left/right edges (24 mobile → 48 desktop). */
+    padding-inline: var(--spacing-page-x);
   }
 
+  @media (min-width: 1024px) {
+    header {
+      padding-inline: var(--spacing-page-x-desktop);
+    }
+  }
+
+  /* main is the flex-1 child of the _app skeleton; only top breathing room
+     below the sticky header is needed here. Horizontal width/padding is
+     owned by the per-page .container-* wrapper. */
   main {
-    grid-area: main;
-    width: 768px;
     padding-top: var(--spacing-5);
-    padding-bottom: var(--footer-height);
   }
 
-  aside {
-    grid-area: aside;
-    margin-top: 0;
-    margin-bottom: var(--footer-height);
-  }
-
+  /* Static footer (issue #149): the min-h-dvh flex-col skeleton pins it to
+     the viewport bottom on short pages without position: fixed. */
   footer {
-    grid-area: footer;
-    height: var(--footer-height);
-    position: fixed;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    margin-top: var(--spacing-24);
+    padding: var(--spacing-12) 0;
+    border-top: 1px solid var(--color-border);
   }
 
-  @media (max-width: 768px) {
+  /* Three-tier responsive model (issue #149):
+       ≤767     mobile  — single column, reduced base font + slim header
+       768–1023 tablet  — single column, container padding bumps at 1024
+       ≥1024    desktop — .layout-with-aside grid activates
+     Component-internal reflows keep using the 800px `max-tablet:` variant. */
+  @media (max-width: 767px) {
     :root {
       font-size: 12px;
-      --header-height: 48px;
-      --footer-height: 38.8px;
     }
 
-    #__next {
-      display: block;
-    }
-
-    main {
-      margin: 0;
-      width: 100%;
-      padding: var(--spacing-3) var(--spacing-5) var(--footer-height);
-    }
-
-    aside {
-      display: none;
+    header {
+      height: var(--header-height-mobile);
     }
   }
 
@@ -449,15 +453,47 @@
 }
 
 @layer components {
-  /* Header layout — three-column grid that collapses on tablet width.
-     Pulled out of Header.tsx where the arbitrary-value classes were noisy. */
-  .header-grid {
-    display: grid;
-    grid-template-columns: auto 1fr auto;
-    grid-template-areas: '. title socialIcons' '. navBar .';
+  /* Page-width containers (issue #149). Pages opt into one of three reading
+     widths; all share centered margins + page-x padding that bumps on desktop.
+       reading 720 — long-form prose (post, about, licenses, 404)
+       content 1120 — card/list pages (index, posts, categories, tags)
+       wide    1280 — reserved for future full-bleed layouts */
+  .container-reading {
+    max-width: var(--container-reading-max);
+    margin-inline: auto;
+    padding-inline: var(--spacing-page-x);
+  }
+  .container-content {
+    max-width: var(--container-content-max);
+    margin-inline: auto;
+    padding-inline: var(--spacing-page-x);
+  }
+  .container-wide {
+    max-width: var(--container-wide-max);
+    margin-inline: auto;
+    padding-inline: var(--spacing-page-x);
+  }
 
-    @media (max-width: 800px) {
-      grid-template-areas: 'title navBar socialIcons';
+  @media (min-width: 1024px) {
+    .container-reading,
+    .container-content,
+    .container-wide {
+      padding-inline: var(--spacing-page-x-desktop);
+    }
+  }
+
+  /* Main + aside grid (issue #149). Defined here as a reusable utility; the
+     follow-up issues (2-2/2-3) compose pages with it. Reflows to a single
+     column ≤1023 so the aside falls below main instead of being hidden. */
+  .layout-with-aside {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) var(--aside-width);
+    gap: var(--spacing-12);
+  }
+
+  @media (max-width: 1023px) {
+    .layout-with-aside {
+      grid-template-columns: 1fr;
     }
   }
 
@@ -509,7 +545,7 @@
     & h3,
     & h4 {
       margin-top: 40px;
-      scroll-margin-top: calc(var(--header-height) + 20px);
+      scroll-margin-top: calc(var(--header-height) + var(--spacing-5));
     }
 
     & h1 {


### PR DESCRIPTION
## 요약
레거시 `#__next` 3-column grid(+ `main width:768px` 하드코드)를 제거하고 `min-h-dvh flex flex-col` 골격으로 재구성. 컨테이너 3종 + slim 헤더(64/56px) + static 푸터로 신뢰감 있는 미니멀 레이아웃 토대를 마련합니다. (#149)

## 변경 사항
- `styles/globals.css`: 레이아웃 토큰 6종(`@theme`), `#__next` grid 제거, 슬림 sticky 헤더(backdrop-blur), static 푸터, `container-reading/content/wide` + `layout-with-aside` 유틸, scroll-margin 토큰화, 미디어쿼리 767/1024 정리
- `pages/_app.tsx`: flex 골격 + app-global aside 제거
- `Header`/`NavBar`/`Footer` 슬림화(단일 행, bg/border 단일 소유)
- `ContentExplorer` `HEADER_HEIGHT` 140→64
- 8개 페이지 컨테이너 래핑(reading 4 / content 4)
- `layout-system-gotchas.md` 문서 추가

## ⚠️ 주의 (후속 이슈로 이관)
- **app-global aside 제거** → `ContentExplorer`(포스트 TOC)는 **#153**, `AsideAdsBanner`는 후속 이슈(2-2/2-3)로 이관. **임시로 사이트 전체 광고 미노출**.
- 모바일 레이아웃 분기점 **768→767px** (컴포넌트 `max-tablet:` 800px는 유지)

## 관련 이슈
Closes #149

## 테스트 체크리스트
- [ ] 1920/1440/1280/1024/800/390px 각 폭에서 시각 회귀 없음 (본문 중앙 정렬, 우측 쏠림 해소)
- [ ] 헤더 64px(데스크탑)/56px(모바일) sticky + backdrop-blur 비침 동작
- [ ] 헤더 좌우 패딩이 ≥1024px에서 컨테이너(48px)와 정렬됨
- [ ] `/404` 등 짧은 페이지에서 푸터가 viewport 바닥에 고정
- [ ] 헤딩 앵커 점프가 64px 헤더 아래로 안착 (scroll-margin)
- [ ] `pnpm run lint` / `pnpm run build` 통과 (확인됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)