### PR TITLE
feat(404): redesign not-found page with editorial layout

### DIFF
--- a/config/meta-contents.ts
+++ b/config/meta-contents.ts
@@ -31,5 +31,9 @@ export const META_CONTENTS = {
   NOT_FOUND: {
     TITLE: '페이지를 찾을 수 없음',
     DESCRIPTION: 'Code Logs | 페이지를 찾을 수 없습니다! 입력하신 URL을 확인해 주세요.',
+    // On-page guidance copy (distinct from the SEO DESCRIPTION above), shown in
+    // the 404 body. Centralized here so all NOT_FOUND strings live in one place.
+    HEADING: '페이지를 찾을 수 없습니다',
+    BODY: '찾으시는 페이지가 존재하지 않거나 이동되었습니다.',
   },
 }

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,23 +1,52 @@
+import { ArrowLeft } from 'lucide-react'
 import CommonMeta from '../components/common-meta/CommonMeta'
-import MainAdsBanner from '../components/ads-banner/MainAdsBanner'
 import blogConfig from '../config/blog.config'
 import { META_CONTENTS } from '../config/meta-contents'
 import TitleUtil from '../utils/TitleUtil'
 
+// The page skeleton (issue #149) renders `<main className="flex-1">` in
+// `_app.tsx`, so this root is a plain <div> (no nested <main>); `h-full` lets it
+// fill that flex-1 main and `justify-center` centers the content vertically.
 const NotFound = () => {
   return (
-    <div className="container-reading">
+    <div className="container-reading h-full flex flex-col items-center justify-center text-center py-16 md:py-24">
       <CommonMeta
         title={TitleUtil.buildPageTitle(META_CONTENTS.NOT_FOUND.TITLE)}
         description={META_CONTENTS.NOT_FOUND.DESCRIPTION}
         url={blogConfig.baseURL}
         imageURL={'/icons/icon-512x512.png'}
+        customMeta={<meta name="robots" content="noindex, follow" />}
       />
-      <section>
-        <h1>Page Not Found</h1>
-      </section>
 
-      <MainAdsBanner />
+      <span
+        aria-hidden
+        className="block font-mono text-8xl md:text-9xl font-bold text-link tracking-tighter leading-none"
+      >
+        404
+      </span>
+      <h1 className="mt-6 text-3xl font-bold text-text-heading">{META_CONTENTS.NOT_FOUND.HEADING}</h1>
+      <p className="mt-3 text-base text-text-muted leading-relaxed max-w-md mx-auto">
+        {META_CONTENTS.NOT_FOUND.BODY}
+      </p>
+
+      <div className="mt-10 flex flex-wrap gap-3 justify-center">
+        {/* Native <a> for full-reload nav, matching the site convention (see about/index.tsx). */}
+        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+        <a
+          href="/"
+          className="inline-flex items-center gap-2 h-10 px-5 rounded-md bg-text-heading text-bg-page text-sm font-medium transition-colors hover:bg-accent"
+        >
+          <ArrowLeft className="w-4 h-4" strokeWidth={1.5} />
+          홈으로
+        </a>
+        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+        <a
+          href="/posts/1"
+          className="inline-flex items-center h-10 px-5 rounded-md ring-1 ring-border text-sm font-medium text-text-body transition-colors hover:bg-bg-subtle hover:text-text-heading"
+        >
+          포스트 보기
+        </a>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## 요약

404 페이지를 신뢰감 있는 미니멀 톤으로 재구성했습니다.
큰 404 디스플레이 + 한글 가이드 카피 + 2개 CTA로 길 잃은 사용자를 안내하고,
에러 페이지에 부적절한 광고를 제거했습니다.

## 변경 사항

- **pages/404.tsx**: 전면 재작성
  - Geist Mono `text-8xl md:text-9xl` 큰 404 디스플레이 추가 (AA-safe `text-link` 색상)
  - h1 "페이지를 찾을 수 없습니다" + 설명 문구 추가
  - Primary CTA "홈으로" (ArrowLeft 아이콘, `/`로 이동)
  - Secondary CTA "포스트 보기" (outlined, `/posts/1`로 이동)
  - `<MainAdsBanner />` 제거
  - `<meta name="robots" content="noindex, follow">` 추가

- **config/meta-contents.ts**: 온페이지 카피 중앙화
  - `NOT_FOUND.HEADING`: '페이지를 찾을 수 없습니다' (on-page h1)
  - `NOT_FOUND.BODY`: '찾으시는 페이지가 존재하지 않거나 이동되었습니다.' (on-page 설명)

## 관련 이슈

Closes #158

## 테스트 체크리스트

- [ ] 404 페이지에 큰 "404" 디스플레이가 Geist Mono로 표시됨
- [ ] "404"에 `aria-hidden="true"` 적용 확인 (스크린리더는 h1만 읽음)
- [ ] h1 "페이지를 찾을 수 없습니다" 표시
- [ ] 설명 "찾으시는 페이지가 존재하지 않거나 이동되었습니다." 표시
- [ ] Primary CTA "홈으로" (ArrowLeft 아이콘 포함) 클릭 시 `/`로 이동
- [ ] Secondary CTA "포스트 보기" 클릭 시 `/posts/1`로 이동
- [ ] 페이지에 광고 없음 (`MainAdsBanner` 제거 확인)
- [ ] 1920/1024/390px 각 폭에서 레이아웃 정상
- [ ] 라이트/다크 모드 모두 시각 회귀 없음
- [ ] Primary CTA 색상 라이트(검정 BG)/다크(흰 BG) 자동 inversion 작동
- [ ] 두 CTA 모두 Tab 키보드 접근 가능
- [ ] 브라우저 DevTools에서 `<meta name="robots" content="noindex, follow">` 확인

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)