### PR TITLE
feat(licenses): redesign /licenses as minimal editorial layout

### DIFF
--- a/config/meta-contents.ts
+++ b/config/meta-contents.ts
@@ -28,6 +28,10 @@ export const META_CONTENTS = {
     TITLE: 'About',
     DESCRIPTION: 'Code Logs | 웹개발과 관련된 정보를 기록하고 공유하는 개인공간 입니다.'
   },
+  LICENSES: {
+    TITLE: 'Licenses',
+    DESCRIPTION: 'Third-party packages used on code-logs.',
+  },
   NOT_FOUND: {
     TITLE: '페이지를 찾을 수 없음',
     DESCRIPTION: 'Code Logs | 페이지를 찾을 수 없습니다! 입력하신 URL을 확인해 주세요.',

--- a/pages/licenses/index.tsx
+++ b/pages/licenses/index.tsx
@@ -1,38 +1,119 @@
-import GoogleAdsenseBanner from '../../components/google-adsense/GoogleAdsenseBanner'
-import KakaoAdfitBanner from '../../components/kakao-adfit/KakaoAdfitBanner'
-import MainAdsBanner from '../../components/ads-banner/MainAdsBanner'
-import RaiseSection from '../../components/raise-section/RaiseSection'
+import { ExternalLink, Search } from 'lucide-react'
+import { useState } from 'react'
+import CommonMeta from '../../components/common-meta/CommonMeta'
+import PageHeader from '../../components/page-header/PageHeader'
 import blogConfig from '../../config/blog.config'
+import { META_CONTENTS } from '../../config/meta-contents'
+import TitleUtil from '../../utils/TitleUtil'
 import licenses from '../../public/licenses.json'
 
-const Licenses = () => {
-  return (
-    <div className="container-reading">
-      <h1>Licenses</h1>
-      <RaiseSection className="grid grid-cols-2 overflow-auto">
-        {Object.keys(licenses).map((depName) => {
-          return (
-            <details
-              className="text-text-muted [&_summary]:py-3 [&_summary]:px-0 [&_a]:text-link"
-              key={depName}
-            >
-              <summary>{depName}</summary>
-              <ul>
-                <li>{(licenses as any)[depName].licenses}</li>
-                {(licenses as any)[depName].repository && (
-                  <li>
-                    <a target="_blank" rel="noreferrer" href={(licenses as any)[depName].repository}>
-                      Repository
-                    </a>
-                  </li>
-                )}
-              </ul>
-            </details>
-          )
-        })}
-      </RaiseSection>
+interface LicenseEntry {
+  licenses: string
+  repository?: string
+}
 
-      <MainAdsBanner />
+interface PackageItem {
+  name: string
+  version: string
+  license: string
+  repository?: string
+}
+
+// Split a license-checker key into name + version. The key joins them with the
+// last "@" (e.g. `caniuse-lite@1.0.0`); scoped packages keep their leading "@"
+// (`@next/env@15.5.18`), so we split on lastIndexOf and guard `<= 0` to treat a
+// key whose only "@" is the scope prefix as version-less.
+function parsePackageKey(key: string): { name: string; version: string } {
+  const lastAt = key.lastIndexOf('@')
+  if (lastAt <= 0) {
+    return { name: key, version: '' }
+  }
+  return { name: key.slice(0, lastAt), version: key.slice(lastAt + 1) }
+}
+
+// Computed once at module scope — the license set is static build-time data.
+const items: PackageItem[] = Object.entries(licenses as Record<string, LicenseEntry>)
+  .map(([key, value]) => ({
+    ...parsePackageKey(key),
+    license: value.licenses,
+    repository: value.repository,
+  }))
+  .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))
+
+const Licenses = () => {
+  const [filter, setFilter] = useState('')
+
+  const filteredItems = filter
+    ? items.filter((item) => item.name.toLowerCase().includes(filter.toLowerCase()))
+    : items
+
+  return (
+    <div className="container-reading py-12">
+      <CommonMeta
+        title={TitleUtil.buildPageTitle(META_CONTENTS.LICENSES.TITLE)}
+        description={META_CONTENTS.LICENSES.DESCRIPTION}
+        url={`${blogConfig.baseURL}/licenses`}
+        imageURL={'/icons/icon-512x512.png'}
+      />
+
+      <PageHeader
+        title="Licenses"
+        subtitle={`Third-party packages used in this site. ${items.length} packages.`}
+        breadcrumb={[{ label: '← About', href: '/about' }]}
+      />
+
+      {/* Inline filter — URL state is overkill here (resets on reload, per #159).
+          SearchInput is not reused because its clear button hard-navigates to
+          /posts/1; only its verified focus-ring wrapper pattern is borrowed. */}
+      <div className="flex h-10 w-full items-center gap-2 rounded-md border border-border bg-bg-page px-3 transition-[box-shadow,border-color] focus-within:border-accent focus-within:shadow-focus">
+        <Search className="shrink-0 text-text-muted" size={18} strokeWidth={1.5} />
+        <input
+          type="search"
+          value={filter}
+          onChange={(event) => setFilter(event.target.value)}
+          placeholder="Filter by package name…"
+          aria-label="Filter by package name"
+          spellCheck={false}
+          className="flex-1 border-none bg-transparent text-text-body outline-none placeholder:text-text-muted focus-visible:shadow-none [&::-webkit-search-cancel-button]:hidden"
+        />
+      </div>
+
+      {filteredItems.length === 0 ? (
+        <p role="status" className="py-8 text-center text-sm text-text-muted">
+          No packages match &quot;{filter}&quot;
+        </p>
+      ) : (
+        <ul role="list" className="mt-6 list-none p-0">
+          {filteredItems.map((item) => (
+            // Rows reflow to 2 cols below 640px (name+version / chip+repo). This
+            // uses max-sm (not the project's usual max-tablet/800px) because the
+            // 4-col grid only feels cramped at true phone widths.
+            <li
+              key={`${item.name}@${item.version}`}
+              className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-x-4 gap-y-2 border-t border-divider py-3 first:border-t-0 max-sm:grid-cols-[1fr_auto]"
+            >
+              <span className="truncate font-mono text-sm text-text-heading">{item.name}</span>
+              <span className="text-xs text-text-muted tabular-nums">{item.version}</span>
+              <span className="inline-flex items-center rounded-sm px-2 py-0.5 text-xs font-medium text-text-body ring-1 ring-border">
+                {item.license}
+              </span>
+              {item.repository ? (
+                <a
+                  href={item.repository}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label={`${item.name} repository`}
+                  className="justify-self-end text-text-muted transition-colors hover:text-accent"
+                >
+                  <ExternalLink className="h-4 w-4" strokeWidth={1.5} />
+                </a>
+              ) : (
+                <span className="h-4 w-4 justify-self-end" aria-hidden />
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## 요약
`/licenses` 페이지를 "신뢰감 있는 미니멀" 톤으로 전면 재작성했습니다. PageHeader + breadcrumb, 클라이언트 필터, 플랫 패키지 행으로 재구성하고 광고·dead code를 제거했습니다.

## 변경 사항
- `PageHeader` + `← About` breadcrumb + `CommonMeta`(LICENSES 메타 신규) 추가
- `parsePackageKey`로 패키지명/버전 분리 (스코프/일반 패키지 모두) + 알파벳 정렬
- 인라인 클라이언트 필터 (`type="search"`, 결과 없을 때 `role="status"` 메시지) — SearchInput의 focus-ring wrapper 패턴 차용
- 플랫 그리드 행: 패키지명(mono) · 버전(tabular-nums) · 단색 라이선스 칩 · repo `ExternalLink` 아이콘
- 모바일(<640px) 2행 reflow (`max-sm:grid-cols-[1fr_auto]`)
- 광고 배너 · `RaiseSection` 사용 · dead imports(AdSense/Adfit) 제거

## 관련 이슈
Closes #159

## 테스트 체크리스트
- [ ] PageHeader가 패키지 수 subtitle과 `← About` breadcrumb(/about 이동) 표시
- [ ] `<head>`에 LICENSES 타이틀/디스크립션/OG 메타 렌더링
- [ ] 필터 입력 시 즉시 부분 문자열 필터링(대소문자 무시), 미일치 시 메시지 표시
- [ ] 스코프 패키지(`@next/env`)와 일반 패키지의 name/version 분리 정확
- [ ] repo 없는 패키지의 그리드 정렬 유지, repo 아이콘 hover accent
- [ ] 390px에서 2행 reflow, 1024/1440/1920에서 회귀 없음
- [ ] 라이트/다크 모두 회귀 없음, 키보드 \`:focus-visible\` 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)