### PR TITLE
chore(meta): description 언어를 한국어로 통일

### DIFF
--- a/config/meta-contents.ts
+++ b/config/meta-contents.ts
@@ -14,7 +14,7 @@ export const META_CONTENTS = {
   },
   CATEGORIES_INDEX: {
     TITLE: 'Categories',
-    DESCRIPTION: 'Browse all categories on code-logs.',
+    DESCRIPTION: 'Code Logs | 전체 카테고리 목록',
   },
   CATEGORY_DETAIL: {
     TITLE: (category: string) => category,
@@ -22,7 +22,7 @@ export const META_CONTENTS = {
   },
   TAGS: {
     TITLE: 'Tags',
-    DESCRIPTION: 'Browse posts by tag on code-logs.',
+    DESCRIPTION: 'Code Logs | 태그별 포스팅 목록',
   },
   ABOUT: {
     TITLE: 'About',
@@ -30,7 +30,7 @@ export const META_CONTENTS = {
   },
   LICENSES: {
     TITLE: 'Licenses',
-    DESCRIPTION: 'Third-party packages used on code-logs.',
+    DESCRIPTION: 'Code Logs | 사용 중인 오픈소스 패키지 라이선스 목록',
   },
   NOT_FOUND: {
     TITLE: '페이지를 찾을 수 없음',


### PR DESCRIPTION
## 요약
영어로 작성되어 있던 메타 description 3건을 한국어로 바꿔 전 페이지의 description 언어를 통일했습니다.

## 변경 사항
- `CATEGORIES_INDEX`: `Browse all categories...` → `Code Logs | 전체 카테고리 목록`
- `TAGS`: `Browse posts by tag...` → `Code Logs | 태그별 포스팅 목록`
- `LICENSES`: `Third-party packages...` → `Code Logs | 사용 중인 오픈소스 패키지 라이선스 목록`

## 관련 이슈
Closes #184

## 테스트 체크리스트
- [ ] `/categories`, `/tags`, `/licenses`의 `<meta name="description">`가 한국어로 노출되는지 확인
- [ ] 기존 한국어 페이지 description에 회귀 없음
- [ ] `pnpm run lint` 통과