### PR TITLE
fix(categories): 인덱스 페이지 QA 개선 (복수형·광고·시맨틱)

### DIFF
--- a/pages/categories/index.tsx
+++ b/pages/categories/index.tsx
@@ -2,6 +2,7 @@ import { NextPage } from 'next'
 import AlphabetNav from '../../components/alphabet-nav/AlphabetNav'
 import CategoriesGrid, { CategoryWithCount } from '../../components/categories-grid/CategoriesGrid'
 import CommonMeta from '../../components/common-meta/CommonMeta'
+import MainAdsBanner from '../../components/ads-banner/MainAdsBanner'
 import PageHeader from '../../components/page-header/PageHeader'
 import blogConfig from '../../config/blog.config'
 import { META_CONTENTS } from '../../config/meta-contents'
@@ -43,8 +44,10 @@ const CategoriesIndex: NextPage<CategoriesIndexProps> = ({ categoriesWithCount }
     )
   )
 
+  const categoryCount = categoriesWithCount.length
+
   return (
-    <div className="container-content py-12">
+    <section className="container-content py-12">
       <CommonMeta
         title={TitleUtil.buildPageTitle(META_CONTENTS.CATEGORIES_INDEX.TITLE)}
         description={META_CONTENTS.CATEGORIES_INDEX.DESCRIPTION}
@@ -55,7 +58,7 @@ const CategoriesIndex: NextPage<CategoriesIndexProps> = ({ categoriesWithCount }
 
       <PageHeader
         title={META_CONTENTS.CATEGORIES_INDEX.TITLE}
-        subtitle={`Browse posts by topic. ${categoriesWithCount.length} categories.`}
+        subtitle={`Browse posts by topic. ${categoryCount} ${categoryCount === 1 ? 'category' : 'categories'}.`}
         breadcrumb={[{ label: 'Posts', href: '/posts/1' }, { label: META_CONTENTS.CATEGORIES_INDEX.TITLE }]}
       />
 
@@ -64,7 +67,9 @@ const CategoriesIndex: NextPage<CategoriesIndexProps> = ({ categoriesWithCount }
       <div className="mt-8">
         <CategoriesGrid categoriesWithCount={categoriesWithCount} enableLetterAnchors />
       </div>
-    </div>
+
+      <MainAdsBanner />
+    </section>
   )
 }
 


### PR DESCRIPTION
## 요약
`/categories` 인덱스 페이지의 페이지 고유 QA. 자매 페이지 `/tags`와 대조해 콘텐츠 복수형 버그와 구조 불일치 3건을 수정했습니다.

## 변경 사항
- subtitle 카테고리 수 단/복수 처리 (1개일 때 "1 categories" → "1 category"). 프로젝트 기존 `count === 1 ? ...` 패턴 재사용
- 콘텐츠 페이지 중 유일하게 누락됐던 `MainAdsBanner`를 하단에 추가 (`/tags` 등과 정합)
- 최상위 컨테이너 `<div>` → `<section>` 시맨틱 정렬

## 관련 이슈
Closes #188

## 테스트 체크리스트
- [ ] `/categories`에서 subtitle 카테고리 수가 문법에 맞게 표시
- [ ] 광고 배너가 `/tags`와 동일하게 페이지 하단에 렌더
- [ ] 라이트/다크 모드 및 1920/1440/1024/800/390 폭에서 레이아웃 정상
- [ ] `pnpm run lint` / `pnpm run build` 통과 (확인 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)