### PR TITLE
fix(post-detail): 카드 엣지 중복 제거 및 관련글 소수 항목 레이아웃 보정

### DIFF
--- a/.claude/docs/post-detail-page-gotchas.md
+++ b/.claude/docs/post-detail-page-gotchas.md
@@ -44,6 +44,12 @@ The post route `/[title]` (issue #153) is a TOC-hybrid reading page: `PostHeader
 - **Why:** `Utterrances.tsx` derives the widget theme from next-themes' `resolvedTheme` (mapping `dark→github-dark`, `light→github-light`). The script is injected once **after** `resolvedTheme` is known (avoids a wrong-theme flash), and later toggles are pushed to the loaded iframe via `postMessage({ type: 'set-theme', theme }, 'https://utteranc.es')`.
 - **Rule:** Do not pass a static `theme` prop or revert to `preferred-color-scheme`. Guard against `resolvedTheme` being `undefined` on first render. The toggle-time `postMessage` is a no-op until the `.utterances-frame` iframe exists — that is expected (the initial theme was already set on the script tag).
 
+### `MoreFromCategory` desktop columns MUST track the visible post count via static literals
+
+- **Symptom:** A category with only 1–2 other posts renders the "More from" cards as lone, narrow, left-skewed cards in a fixed 3-wide grid; OR the grid loses its column count entirely (renders `class="grid  gap-6 …"`) after a "simplification".
+- **Why:** `getStaticProps` slices to `MORE_FROM_CATEGORY_LIMIT = 3`, so the section can receive 1, 2, or 3 posts. The desktop column count is chosen via `DESKTOP_GRID_COLS[Math.min(posts.length, 3)]` (issue #192) so 1–2 posts fill the row instead of skewing left. Tailwind v4 JIT purges any class it cannot see as a whole string — a computed `grid-cols-${n}` would be stripped, leaving no column utility.
+- **Rule:** Keep the column class as a lookup into a static-literal map (`grid-cols-1/2/3`), NEVER a template string. Keep the `?? 'grid-cols-3'` fallback and the `max-tablet:grid-cols-1` mobile override. See [styling-gotchas.md](styling-gotchas.md) for the JIT-detectable-class rule.
+
 ## Conventions
 
 - The post route uses `.post-detail-layout` (defined in `globals.css`), NOT `container-reading` — a centered 1080 shell that becomes `grid-template-columns: minmax(0, 720px) var(--aside-width)` at ≥1024. The TOC aside is `max-lg:hidden`; `MobileToc` is `lg:hidden`. The 1024 breakpoint matches the layout system's desktop tier.
@@ -51,6 +57,7 @@ The post route `/[title]` (issue #153) is a TOC-hybrid reading page: `PostHeader
 - `MainAdsBanner` sits between the body and the footer sections (body-end ↔ PostFooter). Keep it there; the AdSense narrow-viewport guard still applies — see [ads-adsense-rendering-gotchas.md](ads-adsense-rendering-gotchas.md).
 - Prev/Next semantics: `postsDatabase.findPrevious(post)` returns the **older** post (next index in the publishedAt-desc dataset), `findNext` the **newer** one; both return `undefined` at the chronological boundaries. `getStaticProps` MUST coerce these to `null` (Next.js rejects `undefined` in JSON props).
 - `MoreFromCategory` reuses `PostCardGrid` (issue #152), which requires `readingTime` per post — compute it in `getStaticProps` with `calculateReadingTime` ([post-reading-time-gotchas.md](post-reading-time-gotchas.md)), never in the component.
+- Card edge convention is `ring-1 ring-border` with NO `border` (matches `PostCardGrid`). `NavCard` previously carried both `border border-border` and `ring-1 ring-border`, doubling the edge to 2px (issue #192) — keep cards on the single-ring edge so they stay consistent and flip cleanly per theme via `--color-border`.
 - Internal page links use native `<a>` (full reload) site-wide. A literal internal path like `/posts/1` trips the `no-html-link-for-pages` ESLint rule — keep it in a const so the analyzer treats it as dynamic, matching the dynamic hrefs elsewhere.
 
 ## Rationale

--- a/components/post-detail/MoreFromCategory.tsx
+++ b/components/post-detail/MoreFromCategory.tsx
@@ -7,12 +7,23 @@ export interface MoreFromCategoryProps {
   posts: (Post & { readingTime: number })[]
 }
 
+// Static literals so Tailwind's JIT keeps the class (a `grid-cols-${n}` template
+// would be purged). Caps desktop columns at the visible count so 1–2 posts fill
+// the row instead of rendering as lone narrow, left-skewed cards (issue #192).
+const DESKTOP_GRID_COLS: Record<number, string> = {
+  1: 'grid-cols-1',
+  2: 'grid-cols-2',
+  3: 'grid-cols-3',
+}
+
 // "More from {category}" (issue #153): up to 3 latest posts in the same
 // category, rendered with the shared PostCardGrid (#152). Replaces the prior
 // list-disc CategoryPostGroup. Renders nothing when the category has no other
 // posts.
 const MoreFromCategory = ({ category, posts }: MoreFromCategoryProps) => {
   if (!posts.length) return null
+
+  const desktopCols = DESKTOP_GRID_COLS[Math.min(posts.length, 3)] ?? 'grid-cols-3'
 
   return (
     <section>
@@ -29,7 +40,7 @@ const MoreFromCategory = ({ category, posts }: MoreFromCategoryProps) => {
         </a>
       </div>
 
-      <div className="grid grid-cols-3 gap-6 max-tablet:grid-cols-1">
+      <div className={`grid ${desktopCols} gap-6 max-tablet:grid-cols-1`}>
         {posts.map((post) => (
           <PostCardGrid key={post.fileName} post={post} />
         ))}

--- a/components/post-detail/NavCard.tsx
+++ b/components/post-detail/NavCard.tsx
@@ -17,7 +17,7 @@ const NavCard = ({ direction, label, title, description, href }: NavCardProps) =
   return (
     <a
       href={href}
-      className={`card-hover group flex flex-col gap-1 rounded-lg border border-border ring-1 ring-border p-4 no-underline ${
+      className={`card-hover group flex flex-col gap-1 rounded-lg ring-1 ring-border p-4 no-underline ${
         isPrev ? 'items-start text-left' : 'items-end text-right'
       }`}
     >


### PR DESCRIPTION
## 요약

Post 상세 페이지 QA(이슈 #192)에서 발견된 두 가지 디자인 시스템 정합성·엣지 상태 이슈를 해결합니다.
- NavCard의 border+ring 중복(2px 엣지) 제거 → ring-1 ring-border 컨벤션 정합
- MoreFromCategory 소수 항목(1~2개) 좌측 치우침 레이아웃 보정

## 변경 사항

- **NavCard.tsx**: `border border-border ring-1 ring-border` → `ring-1 ring-border` (PostCardGrid 카드 컨벤션 일치)
- **MoreFromCategory.tsx**: `grid-cols-3` 하드코딩 → `DESKTOP_GRID_COLS` 정적 맵 + `min(posts.length, 3)` 기반 컬럼 선택 (1~2개 항목 시 균형 있게 배치, Tailwind v4 JIT purge 회피)
- **.claude/docs/post-detail-page-gotchas.md**: MoreFromCategory 정적 리터럴 클래스 트랩 + NavCard 카드 엣지 컨벤션 문서화

## 관련 이슈

Closes #192

## 테스트 체크리스트

- [ ] Post 상세 페이지의 Prev/Next 카드 엣지가 단일 1px ring으로 보임 (라이트·다크 모드)
- [ ] 같은 카테고리 다른 글이 1개·2개·3개인 포스트의 "More from" 섹션이 좌측 치우침 없이 균형 있게 배치
- [ ] 390/800/1024/1440px 반응형 확인
- [ ] \`pnpm run lint\` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)