### PR TITLE
fix(404): hover 대비 AA 충족 위해 accent-strong 토큰 적용

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -34,7 +34,7 @@ const NotFound = () => {
         {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
         <a
           href="/"
-          className="inline-flex items-center gap-2 h-10 px-5 rounded-md bg-text-heading text-bg-page text-sm font-medium transition-colors hover:bg-accent"
+          className="inline-flex items-center gap-2 h-10 px-5 rounded-md bg-text-heading text-bg-page text-sm font-medium transition-colors hover:bg-accent-strong"
         >
           <ArrowLeft className="w-4 h-4" strokeWidth={1.5} />
           홈으로


### PR DESCRIPTION
## 요약
404 페이지 QA(#194)에서 발견된 Primary 버튼 hover의 WCAG AA 대비 미달을 교정. 디자인 시스템에 이미 문서화된 accent-strong 토큰 규칙을 적용한 단일 1줄 변경.

## 변경 사항
- `pages/404.tsx`: "홈으로" 버튼 hover `bg-accent` → `bg-accent-strong`
  - `bg-accent`(라이트 accent-600) + 흰색 라벨 = 3.74:1, AA(4.5:1) 미달
  - `bg-accent-strong`(accent-700/accent-400)으로 양 모드 AA 충족

## 관련 이슈
Closes #194

## 테스트 체크리스트
- [ ] 라이트 모드: "홈으로" hover 시 진한 틸 배경 + 흰색 라벨 가독
- [ ] 다크 모드: hover 시 밝은 틸 배경 + 어두운 라벨 가독
- [ ] secondary "포스트 보기" 버튼·휴지 상태 회귀 없음
- [ ] 키보드 Tab focus 링 정상 동작
- [ ] \`pnpm run lint\` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)