### PR TITLE
fix(header): scope navbar styles to .site-header class only

### DIFF
--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -23,14 +23,14 @@ export interface HeaderProps {
 // Five-slot header (issue #150). Desktop (≥768): Logo · Nav (centered) · Search ·
 // Theme · Social. Mobile (<768): Logo · Search(icon) · Theme · Hamburger, with the
 // hamburger opening a right slide-in sheet for nav + social. Background/border are
-// owned by the base `header` rule (globals.css) — do NOT add an opaque bg here, it
+// owned by the base `.site-header` rule (globals.css) — do NOT add an opaque bg here, it
 // would defeat the backdrop blur. The mobile sheet state is local: the header owns
 // the menus/socialIcons it needs, so there is nothing to lift.
 const Header = ({ menus, socialIcons, onOpenSearch }: HeaderProps) => {
   const [sheetOpen, setSheetOpen] = useState(false)
 
   return (
-    <header className="flex items-center gap-2 md:gap-4">
+    <header className="site-header flex items-center gap-2 md:gap-4">
       <Logo />
 
       {/* Desktop nav doubles as the flex spacer; on mobile a bare spacer pushes the

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -404,8 +404,11 @@
   /* Slim sticky header (issue #149): 64px desktop / 56px mobile. The
      semi-transparent bg + backdrop-blur let content scroll under a frosted
      bar. Background/border own a single source of truth here — Header.tsx
-     must NOT also set an opaque bg (it would defeat the blur-through). */
-  header {
+     must NOT also set an opaque bg (it would defeat the blur-through).
+     Scoped to .site-header (not the bare `header` element) so semantic
+     <header> blocks elsewhere — PageHeader, About, PostCard — do NOT inherit
+     the navbar's fixed height / sticky / padding (issue: header selector leak). */
+  .site-header {
     height: var(--header-height);
     position: sticky;
     top: 0;
@@ -425,13 +428,13 @@
   /* No backdrop-filter (older Firefox/Safari): drop the blur and use a near-opaque
      bg so scrolled-under content does not bleed through an unblurred translucent bar. */
   @supports not (backdrop-filter: blur(8px)) {
-    header {
+    .site-header {
       background-color: color-mix(in oklab, var(--color-bg-page) 96%, transparent);
     }
   }
 
   @media (min-width: 1024px) {
-    header {
+    .site-header {
       padding-inline: var(--spacing-page-x-desktop);
     }
   }
@@ -461,7 +464,7 @@
       font-size: 12px;
     }
 
-    header {
+    .site-header {
       height: var(--header-height-mobile);
     }
   }


### PR DESCRIPTION
## 요약
CSS 맨 요소 선택자 누수로 인한 레이아웃 버그 수정. 사이트 내비게이션 바 전용 스타일을 `.site-header` 클래스로 한정하여, 페이지 제목 블록(`PageHeader`, About, PostCard 등의 `<header>`)에 대한 스타일 오염을 해결.

## 변경 사항
- `components/header/Header.tsx`: 사이트 내비게이션 `<header>`에 `site-header` 클래스 추가 및 주석 업데이트
- `styles/globals.css`: `header {}` 베이스 규칙 4곳(`@layer base`, `@supports`, 데스크톱 `@media`, 모바일 `@media`)을 `.site-header {}`로 한정. 추가 설명 주석 작성.

## 테스트 체크리스트
- [ ] About 페이지: 제목 블록이 자연 흐름(static)으로 복원되고, 부제가 제목 아래에, 첫 섹션이 부제 아래에 올바르게 배치되는지 확인
- [ ] About 페이지: 제목과 본문이 좌측 정렬되는지 확인 (이전에 48px 우측 밀림)
- [ ] Posts/Categories/Tags/Licenses: 제목이 본문 콘텐츠와 좌측 정렬되는지 확인
- [ ] 사이트 내비게이션 바: 여전히 sticky 포지션과 frosted glass 효과 유지되는지 확인
- [ ] 모바일 뷰포트: 내비게이션 바 높이와 스타일이 정상인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)