### PR TITLE
fix(search): 모바일 검색 input focus 시 iOS Safari 자동 줌 방지

### DIFF
--- a/components/search-input/SearchInput.tsx
+++ b/components/search-input/SearchInput.tsx
@@ -28,9 +28,9 @@ const SearchInput = (props: SearchInputProps) => {
         spellCheck={false}
         // Wrapper owns the focus ring via focus-within; suppress the input's own
         // global :focus-visible box-shadow to avoid a doubled ring.
-        // text-base (16px) on mobile prevents iOS Safari's focus auto-zoom;
-        // md:text-sm restores the smaller desktop size. Pinch zoom stays intact.
-        className="flex-1 border-none bg-transparent text-base text-text-body outline-none placeholder:text-text-muted focus-visible:shadow-none md:text-sm [&::-webkit-search-cancel-button]:hidden"
+        // Use an explicit 16px mobile size so the reduced mobile root font-size
+        // cannot trigger iOS Safari's focus auto-zoom; md:text-sm restores desktop.
+        className="flex-1 border-none bg-transparent text-[16px] text-text-body outline-none placeholder:text-text-muted focus-visible:shadow-none md:text-sm [&::-webkit-search-cancel-button]:hidden"
         {...rest}
       />
       {hasValue && (

--- a/components/search-input/SearchInput.tsx
+++ b/components/search-input/SearchInput.tsx
@@ -28,7 +28,9 @@ const SearchInput = (props: SearchInputProps) => {
         spellCheck={false}
         // Wrapper owns the focus ring via focus-within; suppress the input's own
         // global :focus-visible box-shadow to avoid a doubled ring.
-        className="flex-1 border-none bg-transparent text-text-body outline-none placeholder:text-text-muted focus-visible:shadow-none [&::-webkit-search-cancel-button]:hidden"
+        // text-base (16px) on mobile prevents iOS Safari's focus auto-zoom;
+        // md:text-sm restores the smaller desktop size. Pinch zoom stays intact.
+        className="flex-1 border-none bg-transparent text-base text-text-body outline-none placeholder:text-text-muted focus-visible:shadow-none md:text-sm [&::-webkit-search-cancel-button]:hidden"
         {...rest}
       />
       {hasValue && (


### PR DESCRIPTION
## 요약
모바일(iOS Safari)에서 검색 input에 focus 시 발생하던 자동 줌을 차단합니다. iOS Safari는 `font-size` 16px 미만 input에 focus될 때 화면을 확대하는데, `SearchInput`이 16px 미만 기본값을 상속하고 있었습니다.

## 변경 사항
- `components/search-input/SearchInput.tsx` input className에 `text-base md:text-sm` 추가
  - 모바일: `text-base`(16px)로 자동 줌 차단
  - 데스크톱(`md` 이상): `text-sm`으로 기존 크기 복원
- viewport `maximum-scale`은 건드리지 않아 핀치 줌(접근성) 유지

## 관련 이슈
Closes #220

## 테스트 체크리스트
- [ ] iOS Safari에서 검색 아이콘 탭 후 input focus 시 화면이 확대되지 않는지 확인
- [ ] 모바일에서 input 텍스트가 16px로 표시되는지 확인
- [ ] 데스크톱(md 이상)에서 input 텍스트가 기존처럼 작게(text-sm) 표시되는지 확인
- [ ] 모바일에서 핀치 줌이 여전히 동작하는지 확인