### PR TITLE
fix(search): SearchPalette·licenses input 모바일 자동 줌 방지

### DIFF
--- a/components/search-palette/SearchPalette.tsx
+++ b/components/search-palette/SearchPalette.tsx
@@ -158,7 +158,9 @@ const SearchPalette = ({ open, onClose }: SearchPaletteProps) => {
             aria-expanded={results.length > 0}
             aria-activedescendant={results.length ? `search-result-${activeIndex}` : undefined}
             spellCheck={false}
-            className="flex-1 bg-transparent py-3.5 text-base text-text-body outline-none"
+            // Explicit 16px so the reduced mobile root font-size cannot trigger
+            // iOS Safari's focus auto-zoom; md:text-sm restores desktop size.
+            className="flex-1 bg-transparent py-3.5 text-[16px] text-text-body outline-none md:text-sm"
           />
         </div>
 

--- a/pages/licenses/index.tsx
+++ b/pages/licenses/index.tsx
@@ -85,7 +85,9 @@ const Licenses = () => {
           placeholder="Filter by package name…"
           aria-label="Filter by package name"
           spellCheck={false}
-          className="flex-1 border-none bg-transparent text-text-body outline-none placeholder:text-text-muted focus-visible:shadow-none [&::-webkit-search-cancel-button]:hidden"
+          // Explicit 16px so the reduced mobile root font-size cannot trigger
+          // iOS Safari's focus auto-zoom; md:text-sm restores desktop size.
+          className="flex-1 border-none bg-transparent text-[16px] text-text-body outline-none placeholder:text-text-muted focus-visible:shadow-none md:text-sm [&::-webkit-search-cancel-button]:hidden"
         />
       </div>
 


### PR DESCRIPTION
## 요약
#220 머지 이후에도 모바일에서 검색 input focus 시 자동 줌이 남아있던 문제를 해결합니다. #220은 `SearchInput`만 고쳤고, 정작 모바일 검색에서 열리는 `SearchPalette`와 `/licenses` 필터 input이 누락되어 있었습니다.

## 원인
`styles/globals.css`의 모바일(`max-width: 767px`) `:root { font-size: 12px }` 때문에 rem 기반 `text-base`(=1rem)와 font-size 미지정 input이 모두 **12px**로 계산되어 iOS Safari 자동 줌 조건(16px 미만)에 걸립니다.

## 변경 사항
- `components/search-palette/SearchPalette.tsx`: `text-base` → `text-[16px] md:text-sm`
- `pages/licenses/index.tsx`: font-size 미지정 → `text-[16px] md:text-sm` 추가
- 두 곳 모두 #220의 `SearchInput` 수정과 동일한 절대값 16px 패턴 적용
- viewport `maximum-scale`은 건드리지 않아 핀치 줌(접근성) 유지

## 관련 이슈
Closes #226

## 테스트 체크리스트
- [ ] iOS Safari에서 검색 아이콘 탭 → SearchPalette input focus 시 화면이 확대되지 않는지 확인
- [ ] iOS Safari에서 `/licenses` 페이지 필터 input focus 시 화면이 확대되지 않는지 확인
- [ ] 두 input 모두 모바일에서 16px로 표시되는지 확인
- [ ] 데스크톱(md 이상)에서 text-sm 크기로 표시되는지 확인
- [ ] 모바일에서 핀치 줌이 여전히 동작하는지 확인