### PR TITLE
fix(post-list): 모바일 카드 레이아웃과 태그 검색 동작 개선

### DIFF
--- a/components/google-adsense/GoogleAdsenseBanner.tsx
+++ b/components/google-adsense/GoogleAdsenseBanner.tsx
@@ -16,11 +16,35 @@ declare global {
 // fallback. Skip push() entirely when the slot is too narrow.
 const MIN_SLOT_WIDTH = 125
 
+// adsbygoogle also throws an *asynchronous* `TagError: All 'ins' elements ...
+// already have ads in them` when a client-side re-render remounts in-list ad
+// slots — the /posts search filter swaps the post list (and the MainAdsBanner
+// units interleaved in it), so adsbygoogle reprocesses already-filled slots.
+// The throw originates inside adsbygoogle's own deferred task (no React/our
+// frames on the stack), so a try/catch around push() cannot catch it. Suppress
+// just this error class at the window level so it can't escalate into a fatal
+// Next.js client-side exception fallback (#231). Installed once per session.
+let tagErrorSuppressed = false
+const suppressAdsenseTagError = () => {
+  if (tagErrorSuppressed || typeof window === 'undefined') return
+  tagErrorSuppressed = true
+  window.addEventListener('error', (event) => {
+    // Match only the duplicate-push variant, NOT the narrow-slot
+    // `No slot size for availableWidth` TagError — that one stays observable so
+    // the MIN_SLOT_WIDTH guard's failures aren't masked.
+    if (event.error?.name === 'TagError' && /already have ads/.test(event.error?.message ?? '')) {
+      event.preventDefault()
+    }
+  })
+}
+
 const GoogleAdsenseBanner = (props: GoogleAdsenseBannerProps) => {
   const insRef = useRef<HTMLModElement>(null)
 
   useEffect(() => {
-    if (!insRef.current || insRef.current.offsetWidth < MIN_SLOT_WIDTH) return
+    suppressAdsenseTagError()
+    const ins = insRef.current
+    if (!ins || ins.offsetWidth < MIN_SLOT_WIDTH) return
     window.adsbygoogle = window.adsbygoogle || []
     window.adsbygoogle.push({})
   }, [])

--- a/components/post-card/PostCard.tsx
+++ b/components/post-card/PostCard.tsx
@@ -41,13 +41,17 @@ const PostCard = ({ titleLevel = 3, post }: PostCardProps) => (
 
     {post.thumbnailName && (
       <div className="[grid-area:thumbnail]">
-        <a href={PostUtil.buildLinkURLByTitle(post.title)}>
+        <a href={PostUtil.buildLinkURLByTitle(post.title)} className="block">
           <img
             src={PathUtil.buildImagePath(post.thumbnailName)}
             alt={post.description}
             width="160"
             height="120"
-            className="w-[160px] h-[120px] max-w-full rounded-md object-cover"
+            // Desktop: fixed 160×120 in the auto-sized side column. On mobile the
+            // thumbnail area spans the full card width (max-tablet reflow), so the
+            // image stretches to fill it; aspect-[4/3] preserves the 160:120 ratio
+            // instead of the fixed 120px height (issue #231).
+            className="w-[160px] h-[120px] max-w-full rounded-md object-cover max-tablet:h-auto max-tablet:w-full max-tablet:aspect-[4/3]"
           />
         </a>
       </div>

--- a/database/post-database.ts
+++ b/database/post-database.ts
@@ -40,12 +40,22 @@ class PostDatabase extends Database<Post & { order: number }> {
   }
 
   query(condition: string, limit?: number, skip: number = 0) {
-    const normalizedConditions = condition.split(/\s/).map((cond) => cond.toLowerCase())
+    // Case-insensitive full-string substring match (mirrors SearchPalette's
+    // scoreEntry). The query is matched as a whole phrase against each field and
+    // each individual tag — NOT split on whitespace. Splitting OR-matched every
+    // word against the joined tag string, so a multi-word tag like "web
+    // component" returned posts merely mentioning "component", and an
+    // upper-case tag like "Figma MCP" matched nothing because only the query
+    // was lower-cased. Both broke tag-badge navigation (issue #231).
+    const normalized = condition.trim().toLowerCase()
 
     const foundPosts = this.dataset.filter((post) => {
-      return normalizedConditions.some((cond) => {
-        return post.title.indexOf(cond) >= 0 || post.description.indexOf(cond) >= 0 || post.category.indexOf(cond) >= 0 || post.tags.join('').indexOf(cond) >= 0
-      })
+      return (
+        post.title.toLowerCase().includes(normalized) ||
+        post.description.toLowerCase().includes(normalized) ||
+        post.category.toLowerCase().includes(normalized) ||
+        post.tags.some((tag) => tag.toLowerCase().includes(normalized))
+      )
     })
 
     if (limit !== undefined) return foundPosts.slice(skip, skip + limit)


### PR DESCRIPTION
## 요약
모바일 환경 포스트 목록 카드의 레이아웃 문제(가로 오버플로우·고정 폭 썸네일)와
태그 뱃지 클릭 시 검색 결과 오노출·콘솔 에러를 함께 개선합니다.

## 변경 사항
- **PostCard 썸네일**: 모바일(`max-tablet:`)에서 `w-full h-auto aspect-[4/3]`로
  full-width 전환, 데스크톱은 기존 160×120 유지. 래퍼 `<a>`를 `block`으로.
- **postsDatabase.query()**: 대소문자 무시 + 풀 문자열 substring + 개별 태그 매칭으로
  재작성 (`SearchPalette.scoreEntry`와 일관). 대문자 태그(`Figma MCP`·`CHIPS` 등)가
  0건 반환되거나 멀티워드 태그가 과매칭되던 문제 해소.
- **GoogleAdsenseBanner**: 검색 시 in-list 광고 슬롯이 remount되며 adsbygoogle가
  던지던 비동기 "already have ads" `TagError`를 window 레벨에서 surgical하게 차단.
  narrow-slot `TagError`는 그대로 노출(MIN_SLOT_WIDTH 가드 가시성 유지).

## 관련 이슈
Closes #231

## 테스트 체크리스트
- [ ] 모바일 375px에서 `/posts/1` 카드 가로 스크롤 없음
- [ ] 모바일에서 썸네일이 카드 가로폭 100%, 4:3 비율 유지
- [ ] 데스크톱 1280px에서 썸네일 160×120 유지
- [ ] 대문자/한글/멀티워드 태그(\`Figma MCP\`, \`CHIPS\`, \`Design Tokens\`, \`web component\`, \`개발 프로세스\`) 뱃지 클릭 시 정확한 결과 노출
- [ ] 검색 페이지 콘솔에 \`TagError\` 발생하지 않음
- [ ] 검색 헤더 "Found N posts"와 실제 카드 수 일치