### PR TITLE
fix(layout): 모바일 .layout-with-aside의 bare 1fr을 minmax(0, 1fr)로 교체

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -617,7 +617,7 @@
 
   @media (max-width: 1023px) {
     .layout-with-aside {
-      grid-template-columns: 1fr;
+      grid-template-columns: minmax(0, 1fr);
     }
   }
 


### PR DESCRIPTION
## 요약
모바일 뷰포트(≤1023px)에서 `.layout-with-aside`의 bare `1fr` 트랙이 광고 슬롯(`ins.adsbygoogle`)의 min-content 부풀림으로 인해 가용 폭(327px)을 초과(351px)해, `/posts/[page]` 카드가 컨테이너 `padding-right: 24px`를 시각적으로 침범하던 회귀를 수정한다.

## 변경 사항
- `styles/globals.css:620` 모바일 override를 `grid-template-columns: 1fr` → `grid-template-columns: minmax(0, 1fr)`로 변경. 데스크톱 규칙(`:614`)이 이미 따르는 패턴과 정렬

## 관련 이슈
Closes #233

## 테스트 체크리스트
- [ ] Chrome DevTools 모바일 뷰(375px)로 `/posts/1` 접속 시 첫 카드(`article.post-card-grid`) 우측 가장자리가 뷰포트 끝이 아닌 24px 안쪽에 정렬되는지 확인
- [ ] DevTools에서 `.container-content.layout-with-aside`의 computed `grid-template-columns`가 `327px`로 표시되는지 확인 (이전: `351px`)
- [ ] 광고가 끼지 않는 `/categories/cloud/1` 등 다른 `.layout-with-aside` 사용 페이지에서 모바일 레이아웃 회귀가 없는지 확인
- [ ] 데스크톱(≥1024px) 뷰에서 main+aside 2단 그리드가 정상 동작하는지 확인