### PR TITLE
feat(nav): 메뉴에 Categories, Tags 바로 가기 추가

### DIFF
--- a/config/menu.config.ts
+++ b/config/menu.config.ts
@@ -3,6 +3,8 @@ import { Menu } from '../components/nav-bar/NavBar'
 const menus: Menu[] = [
   { display: 'Home', route: '/' },
   { display: 'Posts', route: '/posts/1' },
+  { display: 'Categories', route: '/categories' },
+  { display: 'Tags', route: '/tags' },
   { display: 'About', route: '/about' },
 ]
 


### PR DESCRIPTION
## 요약
모바일 드로워와 데스크톱 NavBar에 `Categories`, `Tags` 항목을 추가해 카테고리/태그 페이지로 한 번의 탭으로 이동할 수 있게 한다.

## 변경 사항
- `config/menu.config.ts`에 `Categories`, `Tags` 항목 추가
- 노출 순서: `Home → Posts → Categories → Tags → About`
- `menu.config.ts`가 NavBar와 MobileSheet에서 공유되므로 양쪽 자동 반영

## 관련 이슈
Closes #235

## 테스트 체크리스트
- [ ] 모바일 드로워에 `Categories`, `Tags`가 지정 순서로 노출되는지 확인
- [ ] 데스크톱 NavBar에 동일 순서로 노출되는지 확인
- [ ] `Categories` 탭 시 `/categories`, `Tags` 탭 시 `/tags`로 이동하는지 확인
- [ ] 모바일 드로워에서 Escape 닫기 / Tab 포커스 트랩이 추가 항목 포함해서 정상 동작하는지 확인