### PR TITLE
ci(deploy): Node.js 24 지원 액션 메이저 버전 업그레이드

### DIFF
--- a/.claude/docs/build-pipeline-gotchas.md
+++ b/.claude/docs/build-pipeline-gotchas.md
@@ -67,7 +67,7 @@ Read this when: modifying `next.config.js`, `package.json` scripts, `eslint.conf
 ## CI prerequisites
 - `.github/workflows/deploy.yml` uses Corepack to bootstrap pnpm. The `packageManager` field in `package.json` is the source of truth — bumping the pnpm version there updates CI automatically; no `pnpm/action-setup` needed.
 - `pnpm install --frozen-lockfile` in CI fails if `pnpm-lock.yaml` is out of sync with `package.json`. ALWAYS commit lockfile changes alongside dependency edits.
-- The Node version comes from `.nvmrc` via `actions/setup-node@v4` `node-version-file`. Bumping `.nvmrc` updates CI in lockstep.
+- The Node version comes from `.nvmrc` via `actions/setup-node@v6` `node-version-file`. Bumping `.nvmrc` updates CI in lockstep.
 
 ## Rationale
 - Locking pnpm via `packageManager` + Node via `.nvmrc` + Corepack means contributors don't install pnpm globally — `corepack enable` once per machine is the only setup. This eliminates a class of "works on my machine" lockfile churn.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
 
@@ -44,13 +44,13 @@ jobs:
         run: pnpm run docs
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./docs
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## 요약
GitHub가 2026-06-02부터 Actions 러너에서 Node.js 24를 강제하고 2026-09-16 이후 Node.js 20을 제거함에 따라, deploy 워크플로의 액션 5종을 Node.js 24 지원 메이저 버전으로 업그레이드한다.

## 변경 사항
- `actions/checkout` v4 → v6
- `actions/setup-node` v4 → v6
- `actions/configure-pages` v5 → v6
- `actions/upload-pages-artifact` v3 → v5
- `actions/deploy-pages` v4 → v5
- `setup-node@v6`의 자동 캐싱 npm 한정 breaking change는 본 워크플로가 `cache:` 입력을 사용하지 않으므로 영향 없음
- `.claude/docs/build-pipeline-gotchas.md`의 stale 버전 참조(`@v4` → `@v6`) 동기화

## 관련 이슈
Closes #230

## 테스트 체크리스트
- [ ] PR 머지 후 main에 푸시되어 트리거된 `Deploy` 워크플로 실행 성공
- [ ] 워크플로 로그에 `Node.js 20 actions are deprecated` 경고가 더 이상 출력되지 않음
- [ ] 배포된 GitHub Pages 사이트 정상 접근 (https://code-logs.github.io)
- [ ] `pnpm run docs` 단계의 sitemap.xml 및 search-index.json 정상 생성